### PR TITLE
Add REPL leak detection CI

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -1,0 +1,16 @@
+name: Public Repo Guard
+on: [push, pull_request]
+
+jobs:
+  repl-leak-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for REPL infrastructure leaks
+        run: |
+          blocked=$(git ls-tree -r --name-only HEAD | grep -E '^\.(claude|vscode)/|^CLAUDE\.md$|^hooks/|^scripts/claude-' || true)
+          if [ -n "$blocked" ]; then
+            echo "::error::REPL infrastructure detected in public repo:"
+            echo "$blocked"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds `guard.yml` workflow that fails CI if REPL infrastructure files are tracked
- Checks for `.claude/`, `.vscode/`, `CLAUDE.md`, `hooks/`, `scripts/claude-*`

## Test plan
- [ ] CI passes on this PR (no REPL files tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)