### PR TITLE
fix(export): use NSPrintOperation for full-document PDF pagination

### DIFF
--- a/Sources/MarkView/ExportManager.swift
+++ b/Sources/MarkView/ExportManager.swift
@@ -23,7 +23,11 @@ final class ExportManager {
         }
     }
 
-    /// Export via WKWebView's createPDF — produces high-quality output.
+    /// Export full document as PDF using NSPrintOperation — paginates correctly across all content.
+    ///
+    /// WKPDFConfiguration.rect (the previous approach) only captures a fixed viewport rectangle —
+    /// it does not paginate. NSPrintOperation uses WebKit's own layout engine to flow the full
+    /// document across pages, producing correct multi-page output for long documents.
     @MainActor static func exportPDF(from webView: WKWebView, suggestedName: String, errorPresenter: ErrorPresenter) {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.pdf]
@@ -32,28 +36,33 @@ final class ExportManager {
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
-        let config = WKPDFConfiguration()
-        // A4 size in points
-        config.rect = CGRect(x: 0, y: 0, width: 595.28, height: 841.89)
+        let printInfo = NSPrintInfo()
+        // A4 in points (72 pt/inch): 8.27" × 11.69"
+        printInfo.paperSize = NSSize(width: 595.28, height: 841.89)
+        printInfo.leftMargin = 36    // 0.5 inch
+        printInfo.rightMargin = 36
+        printInfo.topMargin = 36
+        printInfo.bottomMargin = 36
+        printInfo.isHorizontallyCentered = false
+        printInfo.isVerticallyCentered = false
+        printInfo.horizontalPagination = .fit
+        printInfo.verticalPagination = .automatic
+        printInfo.jobDisposition = .save
+        printInfo.dictionary()[NSPrintInfo.AttributeKey.jobSavingURL] = url
 
-        webView.createPDF(configuration: config) { result in
-            switch result {
-            case .success(let data):
-                do {
-                    try data.write(to: url)
-                    AppLogger.export.info("PDF exported to \(url.path)")
-                } catch {
-                    Task { @MainActor in
-                        errorPresenter.show("PDF export failed", detail: error.localizedDescription)
-                    }
-                    AppLogger.captureError(error, category: "export", message: "PDF export write failed")
-                }
-            case .failure(let error):
-                Task { @MainActor in
-                    errorPresenter.show("PDF export failed", detail: error.localizedDescription)
-                }
-                AppLogger.captureError(error, category: "export", message: "PDF createPDF failed")
-            }
+        let op = webView.printOperation(with: printInfo)
+        op.showsPrintPanel = false
+        op.showsProgressPanel = false
+
+        if !op.run() {
+            errorPresenter.show("PDF export failed", detail: "Print operation failed")
+            AppLogger.captureError(
+                CocoaError(.fileWriteUnknown),
+                category: "export",
+                message: "NSPrintOperation failed for PDF export"
+            )
+        } else {
+            AppLogger.export.info("PDF exported to \(url.path)")
         }
     }
 }

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -3868,20 +3868,33 @@ runner.test("suppresFileWatcher resets after 250ms — external changes not perm
 // Previously exportPDF notification was posted but never received — clicking
 // "Export PDF..." in the menu did nothing.
 
-// Tier 1 (source): notification wiring + direct webView reference strategy
-// Tier 2 (behavioral): requires WKWebView rendering engine — tested in MarkViewE2ETester
-// TODO(mar-E2E): open fixture .md, trigger Export PDF, assert non-empty .pdf file created on disk
+// Tier 1 (source): notification wiring + pagination implementation guard
+// Tier 2 (behavioral — TODO mar-E2E): open long fixture .md, export PDF,
+//   open with PDFKit, assert PDFDocument.pageCount > 1.
+//   WKPDFConfiguration.rect only captures a viewport rect — always 1 page.
+//   NSPrintOperation.printOperation(with:) paginates the full document.
 runner.test("ContentView handles .exportPDF notification — regression for silent no-op") {
     let source = try String(contentsOfFile: "Sources/MarkView/ContentView.swift", encoding: .utf8)
     try expect(source.contains(".exportPDF"),
         "ContentView must subscribe to .exportPDF notification (was missing — menu item did nothing)")
     try expect(source.contains("ExportManager.exportPDF"),
         "ContentView must call ExportManager.exportPDF when notification received")
-    // Direct ViewModel reference: avoids view-hierarchy search that returns nil in some SwiftUI layouts
     try expect(source.contains("viewModel.previewWebView"),
-        "ContentView must use viewModel.previewWebView for PDF export (direct ref, not only hierarchy search)")
+        "ContentView must use viewModel.previewWebView (direct ref) for PDF export")
     try expect(source.contains("onWebViewCreated"),
-        "WebPreviewView must register WKWebView with viewModel via onWebViewCreated so previewWebView is set")
+        "WebPreviewView must register WKWebView with viewModel via onWebViewCreated")
+}
+
+runner.test("ExportManager uses NSPrintOperation for full-document PDF pagination") {
+    let source = try String(contentsOfFile: "Sources/MarkView/ExportManager.swift", encoding: .utf8)
+    // WKPDFConfiguration.rect captures a viewport rectangle only — always 1 page.
+    // NSPrintOperation paginates the full scrollable document correctly.
+    try expect(!source.contains("WKPDFConfiguration()"),
+        "ExportManager must NOT instantiate WKPDFConfiguration — it only captures a viewport rect, not the full document")
+    try expect(source.contains("NSPrintOperation") || source.contains("printOperation"),
+        "ExportManager must use NSPrintOperation/printOperation for full-document pagination")
+    try expect(source.contains("verticalPagination"),
+        "Print info must set verticalPagination = .automatic for multi-page output")
 }
 
 runner.test("ContentView handles .exportHTML notification") {


### PR DESCRIPTION
## Summary
- Replaces `WKPDFConfiguration.rect` (viewport-only capture) with `NSPrintOperation` (full document pagination)
- `WKPDFConfiguration.rect` always produced a 1-page viewport snapshot regardless of document length
- `NSPrintOperation` uses WebKit's layout engine to flow content across A4 pages correctly

## Test plan
- [x] 383 unit tests passing (`swift run MarkViewTestRunner`)
- [x] New Tier 1 test: asserts `WKPDFConfiguration()` is not instantiated (prevents regression)
- [x] Manually verified: long markdown file exports as multi-page PDF
- [ ] TODO: E2E test asserting `PDFDocument.pageCount > 1` for long fixture (requires full app stack)

## Root cause note
`WKPDFConfiguration.rect` was the signal — "rect" means rectangle capture, not document pagination. Prior test only checked source strings, not page count. Tier 2 test (PDFKit page count assertion) added to TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)