### PR TITLE
fix(export): surface all silent export failures + correct PDF approach

### DIFF
--- a/Sources/MarkView/ContentView.swift
+++ b/Sources/MarkView/ContentView.swift
@@ -122,7 +122,11 @@ struct ContentView: View {
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .exportHTML)) { _ in
-                guard viewModel.isLoaded else { return }
+                AppLogger.export.info("exportHTML notification received — isLoaded=\(viewModel.isLoaded)")
+                guard viewModel.isLoaded else {
+                    errorPresenter.show("Export failed", detail: "No file loaded — open a markdown file first")
+                    return
+                }
                 ExportManager.exportHTML(
                     html: viewModel.renderedHTML,
                     suggestedName: viewModel.fileName,

--- a/Sources/MarkView/ExportManager.swift
+++ b/Sources/MarkView/ExportManager.swift
@@ -49,7 +49,9 @@ final class ExportManager {
         op.showsPrintPanel = true
         op.showsProgressPanel = true
 
-        op.runModal(for: NSApp.keyWindow ?? NSApp.mainWindow!, delegate: nil, didRun: nil, contextInfo: nil)
+        // Use run() not runModal(for:window) — keyWindow goes nil when menu is active,
+        // causing a force-unwrap crash or silent no-op.
+        op.run()
     }
 
     /// Generate PDF to a URL without a save panel — used by MarkViewPDFTester only.

--- a/Sources/MarkView/Strings.swift
+++ b/Sources/MarkView/Strings.swift
@@ -6,8 +6,8 @@ enum Strings {
     // MARK: - Menu Items
     static let openFile = "Open..."
     static let closeWindow = "Close Window"
-    static let exportHTML = "Export HTML..."
-    static let exportPDF = "Export PDF..."
+    static let exportHTML = "Export as HTML..."
+    static let exportPDF = "Print / Save as PDF..."
     static let increaseFontSize = "Increase Font Size"
     static let decreaseFontSize = "Decrease Font Size"
     static let resetFontSize = "Reset Font Size"


### PR DESCRIPTION
HTML export: silent guard now shows "No file loaded" toast.
PDF export: op.run() replaces runModal(for: keyWindow!) — keyWindow goes
nil during menu interaction, causing silent no-op or force-unwrap crash.
Menu label: "Print / Save as PDF..." clarifies the UX (opens Print dialog).
Menu label: "Export as HTML..." makes HTML the obvious primary format.

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
