### PR TITLE
chore(release): npm version 1.2.3 + release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write   # required to create GitHub Releases and upload assets
+      id-token: write   # required for mcp-publisher github-oidc login
 
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +107,9 @@ jobs:
           mkdir -p "${_tmp_pkg}/MarkView.app/Contents/MacOS"
           cp "${{ github.workspace }}/MarkView.app/Contents/MacOS/markview-mcp-server" \
              "${_tmp_pkg}/MarkView.app/Contents/MacOS/"
-          tar -czf "/tmp/MarkView-${VERSION}.tar.gz" -C "${_tmp_pkg}" .
+          # IMPORTANT: do NOT use `-C dir .` — adds ./ prefix breaking postinstall --strip-components=3
+          tar -czf "/tmp/MarkView-${VERSION}.tar.gz" \
+            -C "${_tmp_pkg}" MarkView.app/Contents/MacOS/markview-mcp-server
           rm -rf "${_tmp_pkg}"
           echo "NPM_TARBALL=/tmp/MarkView-${VERSION}.tar.gz" >> $GITHUB_ENV
 
@@ -150,6 +153,21 @@ jobs:
           npm publish --access public
           echo "Published mcp-server-markview@${{ steps.version.outputs.VERSION }} to npm"
 
+      - name: Publish to Official MCP Registry
+        # Uses GitHub OIDC (no stored secret needed) to authenticate with registry.modelcontextprotocol.io
+        # OIDC requires id-token: write permission (set on the job above)
+        run: |
+          if command -v mcp-publisher &>/dev/null; then
+            cd npm
+            mcp-publisher login github-oidc
+            mcp-publisher publish
+            echo "Published io.github.paulhkang94/markview@${{ steps.version.outputs.VERSION }} to MCP registry"
+          else
+            echo "mcp-publisher not found — install: brew install modelcontextprotocol/tap/mcp-publisher"
+            echo "Then manually: cd npm && mcp-publisher login github && mcp-publisher publish"
+          fi
+        continue-on-error: true  # registry publish failure should not block the release
+
       - name: Update Homebrew tap
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -174,3 +192,25 @@ jobs:
           git add Casks/markview.rb
           git commit -m "Update MarkView to ${VERSION}" || echo "No changes to tap"
           git push
+
+  verify-deployment:
+    name: Verify Deployment (clean-room)
+    runs-on: macos-15
+    needs: release
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Wait for npm propagation (60s)
+        run: sleep 60
+
+      - name: Run verify-release.sh (clean-room)
+        run: |
+          # This runner has no MarkView installed — pure clean-room environment.
+          # npm postinstall must download + extract the binary from GitHub releases.
+          bash scripts/verify-release.sh "${{ steps.version.outputs.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,12 +91,24 @@ jobs:
           NOTARIZE_KEY_ID: ${{ secrets.NOTARIZE_KEY_ID }}
           NOTARIZE_ISSUER_ID: ${{ secrets.NOTARIZE_ISSUER_ID }}
 
-      - name: Create release zip
+      - name: Create release artifacts (zip + tar.gz for npm)
         run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          # zip: full app bundle for direct download / Homebrew
           cd /tmp
-          zip -r "MarkView-${{ steps.version.outputs.VERSION }}.zip" \
-            "${{ github.workspace }}/MarkView.app"
-          echo "ARTIFACT=/tmp/MarkView-${{ steps.version.outputs.VERSION }}.zip" >> $GITHUB_ENV
+          zip -r "MarkView-${VERSION}.zip" "${{ github.workspace }}/MarkView.app"
+          echo "ARTIFACT=/tmp/MarkView-${VERSION}.zip" >> $GITHUB_ENV
+
+          # tar.gz: MCP server binary only — consumed by npm postinstall.js
+          # Structure: ./MarkView.app/Contents/MacOS/markview-mcp-server
+          _tmp_pkg="$(mktemp -d)"
+          mkdir -p "${_tmp_pkg}/MarkView.app/Contents/MacOS"
+          cp "${{ github.workspace }}/MarkView.app/Contents/MacOS/markview-mcp-server" \
+             "${_tmp_pkg}/MarkView.app/Contents/MacOS/"
+          tar -czf "/tmp/MarkView-${VERSION}.tar.gz" -C "${_tmp_pkg}" .
+          rm -rf "${_tmp_pkg}"
+          echo "NPM_TARBALL=/tmp/MarkView-${VERSION}.tar.gz" >> $GITHUB_ENV
 
       - name: Generate release notes
         id: notes
@@ -121,11 +133,22 @@ jobs:
             ${{ steps.notes.outputs.NOTES }}
 
             **Installation**: Download `MarkView-${{ steps.version.outputs.VERSION }}.zip`, extract, move to `/Applications`.
-          files: ${{ env.ARTIFACT }}
+          files: |
+            ${{ env.ARTIFACT }}
+            ${{ env.NPM_TARBALL }}
           draft: false
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish npm package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          cd npm
+          npm publish --access public
+          echo "Published mcp-server-markview@${{ steps.version.outputs.VERSION }} to npm"
 
       - name: Update Homebrew tap
         env:

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -22,7 +22,7 @@ const { execFileSync } = require("child_process");
 
 const GITHUB_OWNER = "paulhkang94";
 const GITHUB_REPO = "markview";
-const VERSION = "1.1.3";
+const VERSION = "1.2.3";
 const ARCHIVE_NAME = `MarkView-${VERSION}.tar.gz`;
 const DOWNLOAD_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/v${VERSION}/${ARCHIVE_NAME}`;
 

--- a/npm/server.json
+++ b/npm/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/paulhkang94/markview",
     "source": "github"
   },
-  "version": "1.1.3",
+  "version": "1.2.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "mcp-server-markview",
-      "version": "1.1.3",
+      "version": "1.2.3",
       "transport": {
         "type": "stdio"
       },

--- a/npm/server.json
+++ b/npm/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.paulhkang94/markview",
   "title": "MarkView",
-  "description": "Native macOS Markdown preview. MCP tools: preview_markdown (render content) and open_file (open .md file). GFM tables/task lists, syntax highlighting (18 languages), Mermaid diagrams, Quick Look extension, live reload. Swift, no Electron.",
+  "description": "Native macOS Markdown preview. MCP: preview_markdown, open_file. GFM, Mermaid, syntax highlighting.",
   "repository": {
     "url": "https://github.com/paulhkang94/markview",
     "source": "github"

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -88,6 +88,40 @@ if [ -f "$MCP_MAIN" ]; then
     fi
 fi
 
+# npm/package.json, server.json, postinstall.js — all three must match
+NPM_PKG="$PROJECT_DIR/npm/package.json"
+if [ -f "$NPM_PKG" ]; then
+    NPM_VER=$(python3 -c "import json; print(json.load(open('$NPM_PKG'))['version'])" 2>/dev/null || echo "?")
+    if [ "$NPM_VER" = "$CANONICAL" ]; then
+        echo "  ✓ npm/package.json: $NPM_VER"
+    else
+        echo "  ✗ npm/package.json: $NPM_VER (expected $CANONICAL)"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
+NPM_SERVER="$PROJECT_DIR/npm/server.json"
+if [ -f "$NPM_SERVER" ]; then
+    SERVER_VER=$(python3 -c "import json; print(json.load(open('$NPM_SERVER'))['version'])" 2>/dev/null || echo "?")
+    if [ "$SERVER_VER" = "$CANONICAL" ]; then
+        echo "  ✓ npm/server.json: $SERVER_VER"
+    else
+        echo "  ✗ npm/server.json: $SERVER_VER (expected $CANONICAL)"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
+NPM_POSTINSTALL="$PROJECT_DIR/npm/scripts/postinstall.js"
+if [ -f "$NPM_POSTINSTALL" ]; then
+    POST_VER=$(grep -oE 'const VERSION = "[0-9]+\.[0-9]+\.[0-9]+"' "$NPM_POSTINSTALL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "?")
+    if [ "$POST_VER" = "$CANONICAL" ]; then
+        echo "  ✓ npm/scripts/postinstall.js: $POST_VER"
+    else
+        echo "  ✗ npm/scripts/postinstall.js: $POST_VER (expected $CANONICAL)"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
 # Installed app (advisory only — not an error if not installed)
 INSTALLED_PLIST="/Applications/MarkView.app/Contents/Info.plist"
 if [ -f "$INSTALLED_PLIST" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -190,7 +190,10 @@ if [ -f "$NPM_PKG" ]; then
         _tmp_pkg="$(mktemp -d)"
         mkdir -p "$_tmp_pkg/MarkView.app/Contents/MacOS"
         cp "$NPM_BINARY" "$_tmp_pkg/MarkView.app/Contents/MacOS/"
-        tar -czf "$NPM_ARCHIVE" -C "$_tmp_pkg" .
+        # IMPORTANT: do NOT use `-C dir .` — that adds a ./ prefix to all paths.
+        # postinstall.js uses --strip-components=3 which strips MarkView.app/Contents/MacOS
+        # assuming NO ./ prefix. Use explicit path to get correct structure.
+        tar -czf "$NPM_ARCHIVE" -C "$_tmp_pkg" MarkView.app/Contents/MacOS/markview-mcp-server
         rm -rf "$_tmp_pkg"
         echo "Created: $NPM_ARCHIVE ($(du -sh "$NPM_ARCHIVE" | cut -f1))"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -82,6 +82,35 @@ if [ -f "$MCP_MAIN" ]; then
     echo "Updated MCP server version"
 fi
 
+# npm package — all three files must be kept in sync
+NPM_PKG="$PROJECT_DIR/npm/package.json"
+NPM_SERVER="$PROJECT_DIR/npm/server.json"
+NPM_POSTINSTALL="$PROJECT_DIR/npm/scripts/postinstall.js"
+if [ -f "$NPM_PKG" ]; then
+    # package.json: use node -e to avoid jq dependency
+    node -e "
+const fs = require('fs');
+const p = JSON.parse(fs.readFileSync('$NPM_PKG', 'utf8'));
+p.version = '$NEW_VERSION';
+fs.writeFileSync('$NPM_PKG', JSON.stringify(p, null, 2) + '\n');
+"
+    echo "Updated npm/package.json"
+fi
+if [ -f "$NPM_SERVER" ]; then
+    node -e "
+const fs = require('fs');
+const p = JSON.parse(fs.readFileSync('$NPM_SERVER', 'utf8'));
+p.version = '$NEW_VERSION';
+p.packages[0].version = '$NEW_VERSION';
+fs.writeFileSync('$NPM_SERVER', JSON.stringify(p, null, 2) + '\n');
+"
+    echo "Updated npm/server.json"
+fi
+if [ -f "$NPM_POSTINSTALL" ]; then
+    sed -i '' "s/const VERSION = \"[0-9]*\.[0-9]*\.[0-9]*\";/const VERSION = \"$NEW_VERSION\";/" "$NPM_POSTINSTALL"
+    echo "Updated npm/scripts/postinstall.js"
+fi
+
 # Step 5: Run tests (unless --skip-tests)
 if [ "$SKIP_TESTS" = false ]; then
     echo ""
@@ -148,7 +177,44 @@ else
     echo "WARNING: Dark mode CSS NOT found in binary"
 fi
 
-# Step 11: Summary
+# Step 11: npm — create tar.gz artifact, upload to GitHub release, publish to npm
+# The tar.gz is needed by postinstall.js to extract the MCP server binary.
+# Structure: ./MarkView.app/Contents/MacOS/markview-mcp-server
+if [ -f "$NPM_PKG" ]; then
+    NPM_BINARY="/Applications/MarkView.app/Contents/MacOS/markview-mcp-server"
+    NPM_ARCHIVE="/tmp/MarkView-${NEW_VERSION}.tar.gz"
+
+    if [ -f "$NPM_BINARY" ]; then
+        echo ""
+        echo "--- Building npm release artifact ---"
+        _tmp_pkg="$(mktemp -d)"
+        mkdir -p "$_tmp_pkg/MarkView.app/Contents/MacOS"
+        cp "$NPM_BINARY" "$_tmp_pkg/MarkView.app/Contents/MacOS/"
+        tar -czf "$NPM_ARCHIVE" -C "$_tmp_pkg" .
+        rm -rf "$_tmp_pkg"
+        echo "Created: $NPM_ARCHIVE ($(du -sh "$NPM_ARCHIVE" | cut -f1))"
+
+        # Upload to GitHub release if tag exists
+        if git tag --list "v$NEW_VERSION" | grep -q "v$NEW_VERSION"; then
+            echo "Uploading to GitHub release v$NEW_VERSION..."
+            gh release upload "v$NEW_VERSION" "$NPM_ARCHIVE" --repo paulhkang94/markview 2>&1 || \
+                echo "  ⚠ Upload failed — upload manually: gh release upload v$NEW_VERSION $NPM_ARCHIVE"
+        else
+            echo "  ⚠ Tag v$NEW_VERSION not found — create tag first, then run: gh release upload v$NEW_VERSION $NPM_ARCHIVE"
+        fi
+
+        # Publish to npm
+        echo "Publishing mcp-server-markview@$NEW_VERSION to npm..."
+        cd "$PROJECT_DIR/npm" && npm publish --access public 2>&1
+        cd "$PROJECT_DIR"
+        echo "Published to npm ✓"
+    else
+        echo "  ⚠ MCP server binary not found at $NPM_BINARY — skipping npm publish"
+        echo "    Build the app first with: bash scripts/bundle.sh --install"
+    fi
+fi
+
+# Step 12: Summary
 echo ""
 echo "=== Released MarkView v$NEW_VERSION (build $BUILD_NUMBER) ==="
 echo ""

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -115,13 +115,18 @@ try:
     data = json.load(sys.stdin)
 except:
     print('api_error'); sys.exit(0)
+# Collect all versions for this server; pick the highest (registry may have multiple entries)
+from packaging.version import Version
+versions = []
 for item in data.get('servers', []):
-    s = item.get('server', item)  # handle both nested and flat formats
+    s = item.get('server', item)
     if s.get('name') == 'io.github.paulhkang94/markview':
-        reg_ver = s.get('version', '?')
-        print(reg_ver)
-        sys.exit(0)
-print('not_found')
+        versions.append(s.get('version', '0'))
+if versions:
+    try: print(str(max(versions, key=Version)))
+    except: print(sorted(versions)[-1])
+else:
+    print('not_found')
 " 2>/dev/null || echo "api_error")
 
 case "$MCP_STATUS" in

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -107,28 +107,29 @@ echo ""
 # ─── 6. Official MCP registry ────────────────────────────────────────────────
 echo "6. Official MCP registry"
 MCP_ENTRY=$(curl -sf \
-    "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.paulhkang94/markview" \
+    "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.paulhkang94%2Fmarkview" \
     2>/dev/null || echo "")
-if echo "$MCP_ENTRY" | python3 -c "
+MCP_STATUS=$(echo "$MCP_ENTRY" | python3 -c "
 import json, sys
-data = json.load(sys.stdin)
-servers = data.get('servers', [])
-for s in servers:
+try:
+    data = json.load(sys.stdin)
+except:
+    print('api_error'); sys.exit(0)
+for item in data.get('servers', []):
+    s = item.get('server', item)  # handle both nested and flat formats
     if s.get('name') == 'io.github.paulhkang94/markview':
-        reg_ver = s.get('version_detail', {}).get('version', '?')
-        if reg_ver == '${VERSION}':
-            print(f'  ✓ MCP registry = {reg_ver}')
-            sys.exit(0)
-        else:
-            print(f'  ⚠ MCP registry = {reg_ver} (expected ${VERSION}) — may not have synced yet')
-            sys.exit(2)
-print('  ⚠ Not found in MCP registry results')
-sys.exit(2)
-" 2>/dev/null; then
-    : # pass/warn already printed by python
-else
-    check_warn "MCP registry status unknown (API may be slow to sync)"
-fi
+        reg_ver = s.get('version', '?')
+        print(reg_ver)
+        sys.exit(0)
+print('not_found')
+" 2>/dev/null || echo "api_error")
+
+case "$MCP_STATUS" in
+    "${VERSION}")    check_pass "MCP registry = ${MCP_STATUS}" ;;
+    "not_found")     check_warn "Not found in MCP registry — publish: cd npm && mcp-publisher publish" ;;
+    "api_error")     check_warn "MCP registry API unreachable" ;;
+    *)               check_warn "MCP registry = ${MCP_STATUS} (expected ${VERSION}) — update with: cd npm && mcp-publisher publish" ;;
+esac
 echo ""
 
 # ─── Summary ─────────────────────────────────────────────────────────────────

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify a MarkView release is fully deployed across all distribution channels.
+# Usage: bash scripts/verify-release.sh [VERSION]
+# If VERSION is omitted, reads from Info.plist.
+#
+# Checks:
+#   1. GitHub release has the expected assets (.zip + .tar.gz)
+#   2. npm registry shows the correct version as @latest
+#   3. npm postinstall actually works (downloads + extracts binary)
+#   4. Homebrew tap cask is at the correct version
+#   5. Official MCP registry shows updated version
+#   6. check-version-sync.sh passes (all sources in sync)
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Resolve version
+if [[ $# -gt 0 ]]; then
+    VERSION="$1"
+else
+    VERSION=$(plutil -extract CFBundleShortVersionString raw \
+        "$PROJECT_DIR/Sources/MarkView/Info.plist" 2>/dev/null || echo "")
+fi
+
+if [[ -z "$VERSION" ]]; then
+    echo "ERROR: Could not determine version. Pass as argument: bash $0 1.2.3"
+    exit 1
+fi
+
+echo "=== Verifying MarkView v${VERSION} release ==="
+echo ""
+
+ERRORS=0
+WARNINGS=0
+
+check_pass() { echo "  ✓ $1"; }
+check_fail() { echo "  ✗ $1"; ERRORS=$((ERRORS + 1)); }
+check_warn() { echo "  ⚠ $1"; WARNINGS=$((WARNINGS + 1)); }
+
+# ─── 1. Version sync ─────────────────────────────────────────────────────────
+echo "1. Version sync (check-version-sync.sh)"
+if bash "$PROJECT_DIR/scripts/check-version-sync.sh" 2>&1 | grep -q "✓ All versions in sync"; then
+    check_pass "All local version sources in sync"
+else
+    check_fail "Local version sources OUT OF SYNC — run: bash scripts/check-version-sync.sh"
+fi
+echo ""
+
+# ─── 2. GitHub Release ───────────────────────────────────────────────────────
+echo "2. GitHub Release assets"
+RELEASE_ASSETS=$(gh release view "v${VERSION}" --repo paulhkang94/markview --json assets \
+    --jq '[.assets[] | .name]' 2>/dev/null || echo "[]")
+
+if echo "$RELEASE_ASSETS" | python3 -c "import json,sys; a=json.load(sys.stdin); exit(0 if 'MarkView-${VERSION}.zip' in a else 1)" 2>/dev/null; then
+    check_pass "GitHub release has MarkView-${VERSION}.zip"
+else
+    check_fail "GitHub release MISSING MarkView-${VERSION}.zip"
+fi
+
+if echo "$RELEASE_ASSETS" | python3 -c "import json,sys; a=json.load(sys.stdin); exit(0 if 'MarkView-${VERSION}.tar.gz' in a else 1)" 2>/dev/null; then
+    check_pass "GitHub release has MarkView-${VERSION}.tar.gz (npm artifact)"
+else
+    check_fail "GitHub release MISSING MarkView-${VERSION}.tar.gz — npm postinstall will fail"
+fi
+echo ""
+
+# ─── 3. npm registry ─────────────────────────────────────────────────────────
+echo "3. npm registry"
+NPM_LATEST=$(npm view mcp-server-markview version 2>/dev/null || echo "ERROR")
+if [[ "$NPM_LATEST" == "$VERSION" ]]; then
+    check_pass "npm @latest = ${NPM_LATEST}"
+else
+    check_fail "npm @latest = ${NPM_LATEST} (expected ${VERSION}) — run: cd npm && npm publish --access public"
+fi
+echo ""
+
+# ─── 4. npm postinstall smoke test ───────────────────────────────────────────
+echo "4. npm postinstall smoke test"
+_tmp_install="$(mktemp -d)"
+if (cd "$_tmp_install" && npm install "mcp-server-markview@${VERSION}" --prefer-offline=false 2>&1 | tail -3) > /dev/null 2>&1; then
+    if [[ -f "$_tmp_install/node_modules/mcp-server-markview/bin/markview-mcp-server-binary" ]]; then
+        BINARY_SIZE=$(du -sh "$_tmp_install/node_modules/mcp-server-markview/bin/markview-mcp-server-binary" | cut -f1)
+        check_pass "npm install succeeds + binary extracted (${BINARY_SIZE})"
+    else
+        # Binary may come from /Applications fallback — still acceptable
+        check_warn "npm install succeeded but binary not in node_modules (falling back to /Applications)"
+    fi
+else
+    check_fail "npm install mcp-server-markview@${VERSION} failed"
+fi
+rm -rf "$_tmp_install"
+echo ""
+
+# ─── 5. Homebrew tap ─────────────────────────────────────────────────────────
+echo "5. Homebrew tap"
+TAP_VER=$(curl -sf \
+    "https://raw.githubusercontent.com/paulhkang94/homebrew-markview/main/Casks/markview.rb" \
+    2>/dev/null | grep -oE 'version "[0-9]+\.[0-9]+\.[0-9]+"' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "ERROR")
+if [[ "$TAP_VER" == "$VERSION" ]]; then
+    check_pass "Homebrew tap = ${TAP_VER}"
+else
+    check_warn "Homebrew tap = ${TAP_VER} (expected ${VERSION}) — may not have propagated yet"
+fi
+echo ""
+
+# ─── 6. Official MCP registry ────────────────────────────────────────────────
+echo "6. Official MCP registry"
+MCP_ENTRY=$(curl -sf \
+    "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.paulhkang94/markview" \
+    2>/dev/null || echo "")
+if echo "$MCP_ENTRY" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+servers = data.get('servers', [])
+for s in servers:
+    if s.get('name') == 'io.github.paulhkang94/markview':
+        reg_ver = s.get('version_detail', {}).get('version', '?')
+        if reg_ver == '${VERSION}':
+            print(f'  ✓ MCP registry = {reg_ver}')
+            sys.exit(0)
+        else:
+            print(f'  ⚠ MCP registry = {reg_ver} (expected ${VERSION}) — may not have synced yet')
+            sys.exit(2)
+print('  ⚠ Not found in MCP registry results')
+sys.exit(2)
+" 2>/dev/null; then
+    : # pass/warn already printed by python
+else
+    check_warn "MCP registry status unknown (API may be slow to sync)"
+fi
+echo ""
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo "=== Summary for v${VERSION} ==="
+if [[ $ERRORS -eq 0 && $WARNINGS -eq 0 ]]; then
+    echo "✓ All checks passed — v${VERSION} is fully deployed"
+elif [[ $ERRORS -eq 0 ]]; then
+    echo "⚠ Passed with ${WARNINGS} warning(s) — typically propagation delay, retry in a few minutes"
+else
+    echo "✗ ${ERRORS} failure(s), ${WARNINGS} warning(s) — see above for fixes"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Bump `mcp-server-markview` to v1.2.3
- Automate npm version bump + sync check in release CI
- Add `verify-release.sh` for clean-room e2e release verification
- Correct tar.gz structure + add clean-room e2e verify
- Fix: pick highest MCP registry version when multiple entries exist

## Test plan
- [ ] `bash scripts/verify-release.sh` passes
- [ ] npm version in `package.json` matches `server.json`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)