### PR TITLE
feat: renderComplete message handler + E2E suite hardening (MV-002)

### DIFF
--- a/Sources/MarkView/RecentFilesManager.swift
+++ b/Sources/MarkView/RecentFilesManager.swift
@@ -39,6 +39,11 @@ final class RecentFilesManager: ObservableObject {
         UserDefaults.standard.set(url.path, forKey: lastFileKey)
         // Clear the explicit-close flag so next launch auto-reopens this file.
         UserDefaults.standard.set(false, forKey: explicitlyClosedKey)
+        if ProcessInfo.processInfo.environment["PHK_DEBUG"] != nil {
+            NSLog("[PHK] recordOpen(%@): bundleID=%@ flag-readback=%d",
+                  url.lastPathComponent, Bundle.main.bundleIdentifier ?? "nil",
+                  UserDefaults.standard.bool(forKey: explicitlyClosedKey) ? 1 : 0)
+        }
         pruneAndPublish()
     }
 
@@ -69,6 +74,11 @@ final class RecentFilesManager: ObservableObject {
     /// Suppresses auto-reopen on the next cold launch.
     func markExplicitlyClosed() {
         UserDefaults.standard.set(true, forKey: explicitlyClosedKey)
+        if ProcessInfo.processInfo.environment["PHK_DEBUG"] != nil {
+            NSLog("[PHK] markExplicitlyClosed: bundleID=%@ flag-readback=%d",
+                  Bundle.main.bundleIdentifier ?? "nil",
+                  UserDefaults.standard.bool(forKey: explicitlyClosedKey) ? 1 : 0)
+        }
     }
 
     /// The file to auto-reopen on cold launch, or nil if disabled or no history.

--- a/Sources/MarkView/WebPreviewView.swift
+++ b/Sources/MarkView/WebPreviewView.swift
@@ -31,6 +31,9 @@ struct WebPreviewView: NSViewRepresentable {
         // Register message handler for scroll sync: JS posts source line to Swift.
         let contentController = config.userContentController
         contentController.add(context.coordinator, name: TemplateConstants.scrollSyncHandler)
+        // Render completion: page JS posts exactly once per load (mermaid .then/.catch or
+        // the template timeout fallback) — drives listener install + restore (MV-002).
+        contentController.add(context.coordinator, name: TemplateConstants.renderCompleteHandler)
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.setValue(false, forKey: "drawsBackground")
@@ -259,8 +262,13 @@ struct WebPreviewView: NSViewRepresentable {
 
         // MARK: - WKScriptMessageHandler
 
-        /// Receives source line messages from the JS scroll listener.
+        /// Receives source line messages from the JS scroll listener, plus the
+        /// once-per-load renderComplete signal.
         func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            if message.name == TemplateConstants.renderCompleteHandler {
+                handleRenderComplete()
+                return
+            }
             guard message.name == TemplateConstants.scrollSyncHandler else { return }
 
             if suppressNextScroll {
@@ -460,9 +468,15 @@ struct WebPreviewView: NSViewRepresentable {
             }
             // Images are already inlined as data URIs, so WKWebView only needs access to the
             // temp directory. Never grant access to "/" or user home — least-privilege scope.
+            renderCompleteFired = false
             webView.loadFileURL(tempFile, allowingReadAccessTo: tempFile.deletingLastPathComponent())
-            // Install scroll listener after page loads
-            installScrollListenerAfterLoad(in: webView)
+            // The page's renderComplete message drives scroll-listener install + restore
+            // the moment all transforms finish (MV-002). The 2s timer only covers a page
+            // whose JS died before posting; the fired-flag makes the two paths converge
+            // to exactly one execution per load.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                self?.handleRenderComplete()
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
                 do {
                     try FileManager.default.removeItem(at: tempFile)
@@ -473,19 +487,20 @@ struct WebPreviewView: NSViewRepresentable {
             }
         }
 
-        private func installScrollListenerAfterLoad(in webView: WKWebView) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                guard let self = self else { return }
-                webView.evaluateJavaScript(Self.scrollListenerJS)
+        /// True once the current page load's post-render work ran — renderComplete can
+        /// arrive from page JS AND the fallback timer; only the first wins (MV-002).
+        private var renderCompleteFired = false
 
-                // Restore scroll position after pane toggle (view recreation).
-                // The syncController persists via @State in ContentView, so lastPreviewLine
-                // survives the destroy/recreate cycle.
-                if let line = self.syncController?.lastPreviewLine, line > 0 {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
-                        self?.scrollToSourceLine(line)
-                    }
-                }
+        /// Deterministic post-render hook (MV-002, replaces the 0.5s+0.2s asyncAfter
+        /// timing hacks): installs the scroll listener and restores the persisted
+        /// position exactly once per page load. The syncController persists via @State
+        /// in ContentView, so lastPreviewLine survives the destroy/recreate cycle.
+        private func handleRenderComplete() {
+            guard !renderCompleteFired, let webView = webView else { return }
+            renderCompleteFired = true
+            webView.evaluateJavaScript(Self.scrollListenerJS)
+            if let line = syncController?.lastPreviewLine, line > 0 {
+                scrollToSourceLine(line)
             }
         }
 

--- a/Sources/MarkViewCore/HTMLPipeline.swift
+++ b/Sources/MarkViewCore/HTMLPipeline.swift
@@ -481,10 +481,12 @@ public struct HTMLPipeline {
                         });
                     });
                     window.rendered = true;  // Mermaid async complete — unblock Playwright/WKWebView sentinel
+                    window._markviewPostRenderComplete && window._markviewPostRenderComplete();
                     window._PHK_DEBUG && console.log('[PHK] mermaid.run() resolved — rendered=true (path: mermaid.then)');
                 }).catch(function(err) {
                     window._PHK_DEBUG && console.log('[PHK] mermaid.run() error — rendered=true (path: mermaid.catch)', err);
                     window.rendered = true;  // unblock on error too
+                    window._markviewPostRenderComplete && window._markviewPostRenderComplete();
                 });
             };
             if (document.readyState === 'loading') {

--- a/Sources/MarkViewCore/Resources/template.html
+++ b/Sources/MarkViewCore/Resources/template.html
@@ -391,6 +391,15 @@
             _tocInit();
             window._markviewRebuildTOC = _tocInit;
         })();
+        // Post render completion to the Swift renderComplete handler (WKWebView only;
+        // window.webkit is undefined in Playwright/Chromium — the try/catch makes it a no-op).
+        // Gated to exactly one post per page load: mermaid .then, mermaid .catch, and the
+        // timeout fallback below may all fire on the same load.
+        window._markviewPostRenderComplete = function() {
+            if (window._renderCompletePosted) { return; }
+            window._renderCompletePosted = true;
+            try { window.webkit.messageHandlers.renderComplete.postMessage(true); } catch (e) {}
+        };
         // Playwright/WKWebView sentinel: signals that all synchronous transforms are complete.
         // Mermaid (async) overrides this via HTMLPipeline.injectMermaid -> window.rendered = true.
         // 1200ms is generous enough for KaTeX + Prism on slow CI runners.
@@ -399,6 +408,7 @@
                 window.rendered = true;
                 window._PHK_DEBUG && console.log('[PHK] sentinel: timeout fired (no Mermaid or Mermaid already done)');
             }
+            window._markviewPostRenderComplete();
         }, 1200);
     </script>
 </body>

--- a/Sources/MarkViewCore/TemplateConstants.swift
+++ b/Sources/MarkViewCore/TemplateConstants.swift
@@ -18,4 +18,11 @@ public enum TemplateConstants {
     /// - WebPreviewView: registers handler with this name
     /// - scrollListenerJS: posts messages to this handler
     public static let scrollSyncHandler = "scrollSync"
+
+    /// WKWebView message handler name for render completion. Posted (once per load,
+    /// gated by window._renderCompletePosted) from the same sites that set the
+    /// window.rendered sentinel: mermaid .then/.catch (HTMLPipeline.injectMermaid)
+    /// and the template.html timeout fallback. WebPreviewView drives scroll-listener
+    /// install + position restore off this signal instead of asyncAfter timers.
+    public static let renderCompleteHandler = "renderComplete"
 }

--- a/Tests/E2ETester/AXHelper.swift
+++ b/Tests/E2ETester/AXHelper.swift
@@ -187,6 +187,20 @@ enum AXHelper {
         Thread.sleep(forTimeInterval: 0.05)
     }
 
+    /// Post a keystroke directly to a process (menu key equivalents resolve via
+    /// NSApp.sendEvent). Unlike the HID-tap variant this does not require the app
+    /// to be frontmost — immune to focus-stealing while the suite runs. Also avoids
+    /// AppleScript System Events (separate Automation permission, silent failures).
+    static func keyPress(_ keyCode: CGKeyCode, modifiers: CGEventFlags = [], toPid pid: pid_t) {
+        let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true)
+        let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false)
+        keyDown?.flags = modifiers
+        keyUp?.flags = modifiers
+        keyDown?.postToPid(pid)
+        keyUp?.postToPid(pid)
+        Thread.sleep(forTimeInterval: 0.05)
+    }
+
     // Common key codes
     private static let kVK_ANSI_S: CGKeyCode = 0x01
     private static let kVK_ANSI_E: CGKeyCode = 0x0E

--- a/Tests/E2ETester/TestHelpers.swift
+++ b/Tests/E2ETester/TestHelpers.swift
@@ -141,6 +141,28 @@ struct E2EHelpers {
         return path
     }
 
+    /// Create a LONG temporary markdown file (default 200 numbered sections, ~1,000
+    /// lines) — scroll-position tests need real scrollable height; one-line fixtures
+    /// make "returned to the same position" assertions vacuously true. Each section
+    /// carries a unique, greppable marker heading (`## Section N of ...`).
+    func createLongTempMarkdown(sections: Int = 200, name: String = "e2e-long") -> String {
+        var content = "# Long fixture (\(sections) sections)\n\n"
+        for i in 1...sections {
+            content += """
+            ## Section \(i) of \(sections)
+
+            Paragraph for section \(i). Lorem ipsum dolor sit amet, consectetur
+            adipiscing elit — enough body text that each section occupies real
+            vertical space in the preview.
+
+            - bullet one for section \(i)
+            - bullet two for section \(i)
+
+            """
+        }
+        return createTempMarkdown(content, name: name)
+    }
+
     /// Create a read-only temporary markdown file for testing permission errors.
     func createReadOnlyMarkdown(_ content: String) -> String {
         let path = createTempMarkdown(content, name: "readonly")

--- a/Tests/E2ETester/main.swift
+++ b/Tests/E2ETester/main.swift
@@ -9,7 +9,22 @@ struct TestRunner {
     var failed = 0
     var skipped = 0
 
+    /// `--filter <substring>`: run only tests whose name contains the substring
+    /// (case-insensitive). Filtered-out tests are not counted. Lets a single test
+    /// be iterated on without driving the entire UI suite.
+    let filter: String? = {
+        let args = CommandLine.arguments
+        guard let i = args.firstIndex(of: "--filter"), i + 1 < args.count else { return nil }
+        return args[i + 1].lowercased()
+    }()
+
+    private func matchesFilter(_ name: String) -> Bool {
+        guard let f = filter else { return true }
+        return name.lowercased().contains(f)
+    }
+
     mutating func test(_ name: String, _ body: () throws -> Void) {
+        guard matchesFilter(name) else { return }
         do {
             try body()
             passed += 1
@@ -21,6 +36,7 @@ struct TestRunner {
     }
 
     mutating func skip(_ name: String, reason: String) {
+        guard matchesFilter(name) else { return }
         skipped += 1
         print("  ⊘ \(name) (skipped: \(reason))")
     }
@@ -862,6 +878,125 @@ runner.test("Settings persistence → change theme, relaunch, verify") {
     }
 }
 
+// DEFAULTS-DOMAIN TRAP (cost a full debugging session — do not regress):
+// The app itself is UNSANDBOXED and writes ~/Library/Preferences/com.markview.app.plist.
+// But the sandboxed QuickLook EXTENSION created ~/Library/Containers/com.markview.app/,
+// and the `defaults` CLI silently redirects the bare domain name "com.markview.app" to
+// that container plist — so name-based reads NEVER see the app's writes (verified via
+// the error text: "domain/default pair of (~/Library/Containers/...) does not exist").
+// Explicit PATH-form domains bypass the redirect. App's real plist first; container
+// second (future-proofing if the app ever gets sandboxed).
+let markviewDefaultsDomains = [
+    NSString(string: "~/Library/Preferences/com.markview.app").expandingTildeInPath,
+    NSString(string: "~/Library/Containers/com.markview.app/Data/Library/Preferences/com.markview.app").expandingTildeInPath,
+]
+
+@discardableResult
+func defaultsCmd(_ args: [String]) -> String {
+    let p = Process()
+    p.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+    p.arguments = args
+    let pipe = Pipe()
+    p.standardOutput = pipe
+    p.standardError = FileHandle.nullDevice
+    try? p.run()
+    p.waitUntilExit()
+    let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    return out.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+func readDefaultsBool(_ key: String) -> Bool {
+    markviewDefaultsDomains.contains { defaultsCmd(["read", $0, key]) == "1" }
+}
+
+runner.test("MV-001: closing 1 of 2 tabs must not suppress relaunch auto-reopen") {
+    // Snapshot per-domain state, then clear the flag + force windowRestore on in BOTH
+    // domains (raw-executable launches write the bare "markview" domain).
+    var origClose: [String: String] = [:]
+    var origRestore: [String: String] = [:]
+    for d in markviewDefaultsDomains {
+        origClose[d] = defaultsCmd(["read", d, "didExplicitlyCloseFile"])
+        origRestore[d] = defaultsCmd(["read", d, "windowRestore"])
+        defaultsCmd(["delete", d, "didExplicitlyCloseFile"])
+        defaultsCmd(["write", d, "windowRestore", "-bool", "true"])
+    }
+    defer {
+        app.terminate()
+        for d in markviewDefaultsDomains {
+            if let v = origClose[d], !v.isEmpty { defaultsCmd(["write", d, "didExplicitlyCloseFile", "-bool", v == "1" ? "true" : "false"]) }
+            else { defaultsCmd(["delete", d, "didExplicitlyCloseFile"]) }
+            if let v = origRestore[d], !v.isEmpty { defaultsCmd(["write", d, "windowRestore", "-bool", v == "1" ? "true" : "false"]) }
+            else { defaultsCmd(["delete", d, "windowRestore"]) }
+        }
+    }
+
+    let file1 = helpers.createTempMarkdown("# MV001 Tab One", name: "mv001-one")
+    let file2 = helpers.createTempMarkdown("# MV001 Tab Two", name: "mv001-two")
+
+    try app.launch(args: [file1])
+    Thread.sleep(forTimeInterval: Timing.appLaunch)
+    _ = try app.waitForWindow(timeout: Timing.windowAppear)
+    Thread.sleep(forTimeInterval: Timing.fileLoadRender)
+
+    // Open the second file through the open funnel (CLI path reads only args[1])
+    let script = """
+    tell application "MarkView" to open POSIX file "\(file2)"
+    """
+    var scriptError: NSDictionary?
+    NSAppleScript(source: script)?.executeAndReturnError(&scriptError)
+    Thread.sleep(forTimeInterval: Timing.appLaunch)
+
+    // Close the selected tab (the second file) — 1 of 2. ⌘W posted straight to the
+    // app's pid: the AppleScript menu-click path needs a separate Automation grant
+    // and fails silently without it, which made this assertion pass vacuously.
+    // Key equivalents only route while the app is active, so activate first —
+    // the suite loses frontmost status whenever the user touches the machine.
+    guard let pid1 = app.pid else { throw E2EError.preconditionFailed("no app pid") }
+    NSRunningApplication(processIdentifier: pid1)?.activate(options: [])
+    Thread.sleep(forTimeInterval: 0.5)
+    AXHelper.keyPress(0x0D, modifiers: .maskCommand, toPid: pid1)  // kVK_ANSI_W
+    Thread.sleep(forTimeInterval: 0.8)
+
+    // Prove the close actually happened (selection falls back to the first file) —
+    // otherwise the flag assertion below passes vacuously when the keystroke is lost.
+    if let win = try? app.mainWindow() {
+        let titleAfterClose = helpers.windowTitle(win) ?? ""
+        try expect(titleAfterClose.contains("mv001-one"),
+            "after closing the second tab the first file must be selected (title: '\(titleAfterClose)')")
+    }
+
+    try expect(readDefaultsBool("didExplicitlyCloseFile") == false,
+        "didExplicitlyCloseFile must stay false after closing 1 of 2 tabs (MV-001 regression: flag fired on every close)")
+
+    // Quit and relaunch with NO args — auto-reopen must fire (pre-fix: home screen)
+    app.terminate()
+    try app.launch()
+    Thread.sleep(forTimeInterval: Timing.appLaunch)
+    let window2 = try app.waitForWindow(timeout: Timing.windowAppear)
+    Thread.sleep(forTimeInterval: Timing.fileLoadRender + 0.5)
+    let title = helpers.windowTitle(window2) ?? ""
+    try expect(title.contains("mv001"),
+        "relaunch must auto-reopen a file (title: '\(title)') — bare home screen means auto-reopen was wrongly suppressed")
+
+    // Close the LAST tab — now the flag must be set
+    guard let pid2 = app.pid else { throw E2EError.preconditionFailed("no app pid after relaunch") }
+    NSRunningApplication(processIdentifier: pid2)?.activate(options: [])
+    Thread.sleep(forTimeInterval: 0.5)
+    AXHelper.keyPress(0x0D, modifiers: .maskCommand, toPid: pid2)  // kVK_ANSI_W
+    Thread.sleep(forTimeInterval: 0.8)
+    let titleAfterLastClose = (try? app.mainWindow()).flatMap { helpers.windowTitle($0) } ?? "<no window>"
+    try expect(readDefaultsBool("didExplicitlyCloseFile") == true,
+        "didExplicitlyCloseFile must be true after closing the LAST tab (post-close title: '\(titleAfterLastClose)')")
+}
+
+// Spec placeholder for MV-003/MV-005 (per-tab scroll position survives tab switch):
+// open TWO long files via helpers.createLongTempMarkdown() (~1,000 lines each — real
+// scrollable height, unique "## Section N" markers), scroll tab A deep, switch A→B→A,
+// assert the preview restored to the same section (not the top). Requires TabState
+// scroll persistence (MV-003) + renderComplete-driven restore wiring (MV-005).
+runner.skip("MV-003/005: tab switch returns to the same scroll position",
+    reason: "feature pending — TabState scroll persistence (MV-003) + restore wiring (MV-005) not yet implemented; long fixtures ready via createLongTempMarkdown()")
+
 print("")
 
 // ========== Tier 5: Integration ==========
@@ -914,12 +1049,15 @@ runner.test("Quick Look preview produces output") {
     process.standardOutput = FileHandle.nullDevice
     process.standardError = FileHandle.nullDevice
 
-    // qlmanage -p opens a preview window — just verify it doesn't crash
+    // qlmanage -p opens a preview window — just verify it doesn't crash.
+    // Reap unconditionally (SIGTERM, then SIGKILL): a leaked qlmanage stays in the Dock.
     try process.run()
-    Thread.sleep(forTimeInterval: 2.0)
-    if process.isRunning {
-        process.terminate()
+    defer {
+        if process.isRunning { process.terminate() }
+        Thread.sleep(forTimeInterval: 0.3)
+        if process.isRunning { kill(process.processIdentifier, SIGKILL) }
     }
+    Thread.sleep(forTimeInterval: 2.0)
     try expect(true, "qlmanage completed without crash")
 }
 
@@ -1106,8 +1244,26 @@ print("")
 
 print("--- Tier 5: Quick Look Preview ---")
 
+/// Kill every qlmanage instance on the system. Called before each spawn (single-instance
+/// guarantee) and at suite teardown — leaked previews otherwise pile up in the Dock.
+func killAllQL() {
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+    task.arguments = ["-x", "qlmanage"]
+    task.standardOutput = FileHandle.nullDevice
+    task.standardError = FileHandle.nullDevice
+    try? task.run()
+    task.waitUntilExit()
+    Thread.sleep(forTimeInterval: 0.3)
+}
+
 /// Launch qlmanage -p, find its window via AX, return window element + PID.
+/// Kills any pre-existing qlmanage first, and reaps its own spawn on the
+/// no-window failure path — the earlier version leaked one qlmanage instance
+/// per failed precondition (three Dock icons after one bad run).
 func launchQLPreview(file: String) -> (window: AXUIElement, pid: pid_t)? {
+    killAllQL()
+
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/qlmanage")
     process.arguments = ["-p", file]
@@ -1123,13 +1279,21 @@ func launchQLPreview(file: String) -> (window: AXUIElement, pid: pid_t)? {
     let windows: [AXUIElement] = AXHelper.children(appElement).filter {
         AXHelper.role($0) == kAXWindowRole
     }
-    guard let window = windows.first else { return nil }
+    guard let window = windows.first else {
+        killQL(pid)
+        return nil
+    }
     return (window, pid)
 }
 
 func killQL(_ pid: pid_t) {
     kill(pid, SIGTERM)
     Thread.sleep(forTimeInterval: 0.5)
+    // qlmanage occasionally ignores SIGTERM while its preview panel is animating
+    if kill(pid, 0) == 0 {
+        kill(pid, SIGKILL)
+        Thread.sleep(forTimeInterval: 0.2)
+    }
 }
 
 let qlFixturePath = FileManager.default.currentDirectoryPath + "/Tests/TestRunner/Fixtures/basic.md"
@@ -1498,6 +1662,11 @@ print("")
 // ========== Summary ==========
 
 helpers.cleanupTempFiles()
+// Suite teardown: never leave preview processes behind, regardless of which
+// tests ran or how they failed (leaked qlmanage instances pile up in the Dock).
+killAllQL()
+app.terminate()
+
 runner.summary()
 
 if runner.failed > 0 {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -3780,6 +3780,42 @@ runner.test("TabManager: selectNext and selectPrevious wrap at boundaries") {
         "selectPrevious must wrap from first tab to last via (idx + count - 1) % count")
 }
 
+runner.test("MV-002: assembled HTML posts renderComplete alongside every window.rendered site") {
+    // Behavioral on pipeline OUTPUT: the same sites that set the window.rendered
+    // sentinel must post to the renderComplete WKScriptMessageHandler, or Swift-side
+    // restore stays on asyncAfter timing hacks.
+    let pipeline = HTMLPipeline.loadFromBundle()
+    // Use the REAL template (the app's PreviewViewModel path) — the built-in
+    // wrapInTemplate fallback has no sentinel script and would mask a regression.
+    let realTemplate = try String(
+        contentsOf: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Sources/MarkViewCore/Resources/template.html"),
+        encoding: .utf8)
+    let mermaidBody = MarkdownRenderer.renderHTML(from: "# T\n\n```mermaid\ngraph TD; A-->B;\n```")
+    let mermaidDoc = pipeline.assemble(MarkdownRenderer.wrapInTemplate(mermaidBody, template: realTemplate))
+    // The shared gated helper must exist and actually post to the Swift handler
+    try expect(mermaidDoc.contains("messageHandlers.renderComplete"),
+        "template must define a helper that posts to the renderComplete message handler")
+    try expect(mermaidDoc.contains("_renderCompletePosted"),
+        "renderComplete posts must be gated by a _renderCompletePosted flag (once per load)")
+    // Every window.rendered site must invoke the helper: mermaid .then, .catch, timeout fallback
+    let helperCalls = mermaidDoc.components(separatedBy: "_markviewPostRenderComplete()").count - 1
+    try expect(helperCalls >= 3,
+        "mermaid doc must invoke the post helper from .then, .catch, and the template timeout fallback (found \(helperCalls) call sites)")
+    let plainDoc = pipeline.assemble(
+        MarkdownRenderer.wrapInTemplate(MarkdownRenderer.renderHTML(from: "# T"), template: realTemplate))
+    try expect(plainDoc.components(separatedBy: "_markviewPostRenderComplete()").count - 1 >= 1,
+        "plain doc must invoke the post helper from the template timeout fallback")
+}
+
+runner.test("MV-002: WebPreviewView registers renderComplete with a once-per-load guard") {
+    let wpvSource = try! String(contentsOfFile: "Sources/MarkView/WebPreviewView.swift", encoding: .utf8)
+    try expect(wpvSource.contains("TemplateConstants.renderCompleteHandler"),
+        "WebPreviewView must register the renderComplete message handler (MV-002)")
+    try expect(wpvSource.contains("renderCompleteFired"),
+        "Coordinator must dedupe renderComplete per load — it can arrive from both mermaid completion and the timeout fallback")
+}
+
 runner.test("MV-001: unloadFile must not mark explicitly-closed (fires on EVERY tab close)") {
     // Regression: markExplicitlyClosed() inside unloadFile() poisoned relaunch
     // auto-reopen whenever ANY tab closed, even with other tabs still open.

--- a/Tests/playwright/fixtures/alerts.html
+++ b/Tests/playwright/fixtures/alerts.html
@@ -416,6 +416,15 @@ This is a caution callout.</p>
             _tocInit();
             window._markviewRebuildTOC = _tocInit;
         })();
+        // Post render completion to the Swift renderComplete handler (WKWebView only;
+        // window.webkit is undefined in Playwright/Chromium — the try/catch makes it a no-op).
+        // Gated to exactly one post per page load: mermaid .then, mermaid .catch, and the
+        // timeout fallback below may all fire on the same load.
+        window._markviewPostRenderComplete = function() {
+            if (window._renderCompletePosted) { return; }
+            window._renderCompletePosted = true;
+            try { window.webkit.messageHandlers.renderComplete.postMessage(true); } catch (e) {}
+        };
         // Playwright/WKWebView sentinel: signals that all synchronous transforms are complete.
         // Mermaid (async) overrides this via HTMLPipeline.injectMermaid -> window.rendered = true.
         // 1200ms is generous enough for KaTeX + Prism on slow CI runners.
@@ -424,6 +433,7 @@ This is a caution callout.</p>
                 window.rendered = true;
                 window._PHK_DEBUG && console.log('[PHK] sentinel: timeout fired (no Mermaid or Mermaid already done)');
             }
+            window._markviewPostRenderComplete();
         }, 1200);
     </script>
 <script>/**
@@ -3498,10 +3508,12 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
                 });
             });
             window.rendered = true;  // Mermaid async complete — unblock Playwright/WKWebView sentinel
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() resolved — rendered=true (path: mermaid.then)');
         }).catch(function(err) {
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() error — rendered=true (path: mermaid.catch)', err);
             window.rendered = true;  // unblock on error too
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
         });
     };
     if (document.readyState === 'loading') {

--- a/Tests/playwright/fixtures/code-blocks.html
+++ b/Tests/playwright/fixtures/code-blocks.html
@@ -521,6 +521,15 @@ Just monospace text
             _tocInit();
             window._markviewRebuildTOC = _tocInit;
         })();
+        // Post render completion to the Swift renderComplete handler (WKWebView only;
+        // window.webkit is undefined in Playwright/Chromium — the try/catch makes it a no-op).
+        // Gated to exactly one post per page load: mermaid .then, mermaid .catch, and the
+        // timeout fallback below may all fire on the same load.
+        window._markviewPostRenderComplete = function() {
+            if (window._renderCompletePosted) { return; }
+            window._renderCompletePosted = true;
+            try { window.webkit.messageHandlers.renderComplete.postMessage(true); } catch (e) {}
+        };
         // Playwright/WKWebView sentinel: signals that all synchronous transforms are complete.
         // Mermaid (async) overrides this via HTMLPipeline.injectMermaid -> window.rendered = true.
         // 1200ms is generous enough for KaTeX + Prism on slow CI runners.
@@ -529,6 +538,7 @@ Just monospace text
                 window.rendered = true;
                 window._PHK_DEBUG && console.log('[PHK] sentinel: timeout fired (no Mermaid or Mermaid already done)');
             }
+            window._markviewPostRenderComplete();
         }, 1200);
     </script>
 <script>/**
@@ -3603,10 +3613,12 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
                 });
             });
             window.rendered = true;  // Mermaid async complete — unblock Playwright/WKWebView sentinel
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() resolved — rendered=true (path: mermaid.then)');
         }).catch(function(err) {
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() error — rendered=true (path: mermaid.catch)', err);
             window.rendered = true;  // unblock on error too
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
         });
     };
     if (document.readyState === 'loading') {

--- a/Tests/playwright/fixtures/diff.html
+++ b/Tests/playwright/fixtures/diff.html
@@ -423,6 +423,15 @@
             _tocInit();
             window._markviewRebuildTOC = _tocInit;
         })();
+        // Post render completion to the Swift renderComplete handler (WKWebView only;
+        // window.webkit is undefined in Playwright/Chromium — the try/catch makes it a no-op).
+        // Gated to exactly one post per page load: mermaid .then, mermaid .catch, and the
+        // timeout fallback below may all fire on the same load.
+        window._markviewPostRenderComplete = function() {
+            if (window._renderCompletePosted) { return; }
+            window._renderCompletePosted = true;
+            try { window.webkit.messageHandlers.renderComplete.postMessage(true); } catch (e) {}
+        };
         // Playwright/WKWebView sentinel: signals that all synchronous transforms are complete.
         // Mermaid (async) overrides this via HTMLPipeline.injectMermaid -> window.rendered = true.
         // 1200ms is generous enough for KaTeX + Prism on slow CI runners.
@@ -431,6 +440,7 @@
                 window.rendered = true;
                 window._PHK_DEBUG && console.log('[PHK] sentinel: timeout fired (no Mermaid or Mermaid already done)');
             }
+            window._markviewPostRenderComplete();
         }, 1200);
     </script>
 <script>/**
@@ -3558,10 +3568,12 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
                 });
             });
             window.rendered = true;  // Mermaid async complete — unblock Playwright/WKWebView sentinel
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() resolved — rendered=true (path: mermaid.then)');
         }).catch(function(err) {
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() error — rendered=true (path: mermaid.catch)', err);
             window.rendered = true;  // unblock on error too
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
         });
     };
     if (document.readyState === 'loading') {

--- a/Tests/playwright/fixtures/golden-corpus.html
+++ b/Tests/playwright/fixtures/golden-corpus.html
@@ -805,6 +805,15 @@ and KaTeX math rendering<sup class="footnote-ref"><a href="#fn-katex" id="fnref-
             _tocInit();
             window._markviewRebuildTOC = _tocInit;
         })();
+        // Post render completion to the Swift renderComplete handler (WKWebView only;
+        // window.webkit is undefined in Playwright/Chromium — the try/catch makes it a no-op).
+        // Gated to exactly one post per page load: mermaid .then, mermaid .catch, and the
+        // timeout fallback below may all fire on the same load.
+        window._markviewPostRenderComplete = function() {
+            if (window._renderCompletePosted) { return; }
+            window._renderCompletePosted = true;
+            try { window.webkit.messageHandlers.renderComplete.postMessage(true); } catch (e) {}
+        };
         // Playwright/WKWebView sentinel: signals that all synchronous transforms are complete.
         // Mermaid (async) overrides this via HTMLPipeline.injectMermaid -> window.rendered = true.
         // 1200ms is generous enough for KaTeX + Prism on slow CI runners.
@@ -813,6 +822,7 @@ and KaTeX math rendering<sup class="footnote-ref"><a href="#fn-katex" id="fnref-
                 window.rendered = true;
                 window._PHK_DEBUG && console.log('[PHK] sentinel: timeout fired (no Mermaid or Mermaid already done)');
             }
+            window._markviewPostRenderComplete();
         }, 1200);
     </script>
 <script>/**
@@ -3887,10 +3897,12 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
                 });
             });
             window.rendered = true;  // Mermaid async complete — unblock Playwright/WKWebView sentinel
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() resolved — rendered=true (path: mermaid.then)');
         }).catch(function(err) {
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() error — rendered=true (path: mermaid.catch)', err);
             window.rendered = true;  // unblock on error too
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
         });
     };
     if (document.readyState === 'loading') {

--- a/Tests/playwright/fixtures/math.html
+++ b/Tests/playwright/fixtures/math.html
@@ -402,6 +402,15 @@
             _tocInit();
             window._markviewRebuildTOC = _tocInit;
         })();
+        // Post render completion to the Swift renderComplete handler (WKWebView only;
+        // window.webkit is undefined in Playwright/Chromium — the try/catch makes it a no-op).
+        // Gated to exactly one post per page load: mermaid .then, mermaid .catch, and the
+        // timeout fallback below may all fire on the same load.
+        window._markviewPostRenderComplete = function() {
+            if (window._renderCompletePosted) { return; }
+            window._renderCompletePosted = true;
+            try { window.webkit.messageHandlers.renderComplete.postMessage(true); } catch (e) {}
+        };
         // Playwright/WKWebView sentinel: signals that all synchronous transforms are complete.
         // Mermaid (async) overrides this via HTMLPipeline.injectMermaid -> window.rendered = true.
         // 1200ms is generous enough for KaTeX + Prism on slow CI runners.
@@ -410,6 +419,7 @@
                 window.rendered = true;
                 window._PHK_DEBUG && console.log('[PHK] sentinel: timeout fired (no Mermaid or Mermaid already done)');
             }
+            window._markviewPostRenderComplete();
         }, 1200);
     </script>
 <script>/**
@@ -3484,10 +3494,12 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
                 });
             });
             window.rendered = true;  // Mermaid async complete — unblock Playwright/WKWebView sentinel
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() resolved — rendered=true (path: mermaid.then)');
         }).catch(function(err) {
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() error — rendered=true (path: mermaid.catch)', err);
             window.rendered = true;  // unblock on error too
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
         });
     };
     if (document.readyState === 'loading') {

--- a/Tests/playwright/fixtures/mermaid.html
+++ b/Tests/playwright/fixtures/mermaid.html
@@ -480,6 +480,15 @@
             _tocInit();
             window._markviewRebuildTOC = _tocInit;
         })();
+        // Post render completion to the Swift renderComplete handler (WKWebView only;
+        // window.webkit is undefined in Playwright/Chromium — the try/catch makes it a no-op).
+        // Gated to exactly one post per page load: mermaid .then, mermaid .catch, and the
+        // timeout fallback below may all fire on the same load.
+        window._markviewPostRenderComplete = function() {
+            if (window._renderCompletePosted) { return; }
+            window._renderCompletePosted = true;
+            try { window.webkit.messageHandlers.renderComplete.postMessage(true); } catch (e) {}
+        };
         // Playwright/WKWebView sentinel: signals that all synchronous transforms are complete.
         // Mermaid (async) overrides this via HTMLPipeline.injectMermaid -> window.rendered = true.
         // 1200ms is generous enough for KaTeX + Prism on slow CI runners.
@@ -488,6 +497,7 @@
                 window.rendered = true;
                 window._PHK_DEBUG && console.log('[PHK] sentinel: timeout fired (no Mermaid or Mermaid already done)');
             }
+            window._markviewPostRenderComplete();
         }, 1200);
     </script>
 <script>/**
@@ -3562,10 +3572,12 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
                 });
             });
             window.rendered = true;  // Mermaid async complete — unblock Playwright/WKWebView sentinel
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() resolved — rendered=true (path: mermaid.then)');
         }).catch(function(err) {
             window._PHK_DEBUG && console.log('[PHK] mermaid.run() error — rendered=true (path: mermaid.catch)', err);
             window.rendered = true;  // unblock on error too
+            window._markviewPostRenderComplete && window._markviewPostRenderComplete();
         });
     };
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## What changed

**MV-002 — deterministic render-completion signal.** The JS `window.rendered` sentinel was observed by nothing Swift-side; scroll-listener install + position restore ran on 0.5s+0.2s `asyncAfter` timing hacks. Now a gated `window._markviewPostRenderComplete()` helper (once per load) posts to a new `renderComplete` WKScriptMessageHandler from the exact sites that set `window.rendered` (mermaid `.then`/`.catch` + the 1200ms template fallback), and the Coordinator drives install+restore off that signal with a 2s degraded-path timer converging through the same once-per-load flag. Prerequisite for MV-005/018/019.

**E2E suite hardening** (fallout from automating the MV-001 relaunch check):
- New end-to-end MV-001 test: close 1 of 2 tabs → flag stays false → relaunch auto-reopens → close last tab → flag set.
- qlmanage leak fixed (spawns were never reaped on the no-window path — one Dock icon per failed precondition) + suite teardown sweep.
- `defaults` CLI domain-redirect trap fixed + documented (unsandboxed app writes `~/Library/Preferences`, CLI silently reads the QuickLook extension's container).
- `--filter <substring>` for the E2E runner; pid-targeted CGEvent keystrokes; ~1,000-line fixture helper + skipped spec test for MV-003/005 scroll restore.

## Test plan
- Tests written first, failed pre-implementation: pipeline-output behavioral + source-inspection (TestRunner 308/308).
- `make playwright` exit 0 (66 tests; template + pipeline changed).
- `swift run MarkViewE2ETester --filter mv-001` green.
- `python3 scripts/verify.py` all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)