### PR TITLE
fix(verify): write HA-008 tiered verify stamps; fix dead global stamp path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ playwright-fixtures:
 	bash scripts/gen-playwright-fixtures.sh
 
 playwright: playwright-fixtures
-	cd Tests/playwright && npx playwright test && date +%s > ../../.last-verify-at && cd ../.. && bash scripts/bundle.sh --install
+	cd Tests/playwright && npx playwright test && printf 'TIER=test\nTS=%s\n' "$$(date +%s)" > ../../.last-verify-at && cd ../.. && bash scripts/bundle.sh --install
 
 playwright-headed: playwright-fixtures
 	cd Tests/playwright && npx playwright test --headed

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -52,7 +52,10 @@ if [[ "$RENDER_CRITICAL" -gt 0 ]]; then
     if [[ ! -f "$STAMP" ]]; then
         fail "Render-critical file changed. Run: make playwright   (then re-commit)"
     else
-        AGE=$(( $(date +%s) - $(cat "$STAMP") ))
+        # HA-008 format "TIER=x\nTS=<epoch>"; fall back to legacy bare epoch
+        STAMP_TS=$(grep -oE '^TS=[0-9]+' "$STAMP" | cut -d= -f2 || true)
+        [[ -z "$STAMP_TS" ]] && STAMP_TS=$(head -1 "$STAMP")
+        AGE=$(( $(date +%s) - ${STAMP_TS:-0} ))
         if [[ "$AGE" -gt 600 ]]; then
             fail "Playwright tests stale (${AGE}s ago). Run: make playwright   (then re-commit)"
         else

--- a/scripts/render-verify-gate.sh
+++ b/scripts/render-verify-gate.sh
@@ -41,7 +41,10 @@ done
 
 # Check stamp freshness
 if [[ -f "$STAMP" ]]; then
-    stamp_age=$(( $(date +%s) - $(cat "$STAMP") ))
+    # HA-008 format "TIER=x\nTS=<epoch>"; fall back to legacy bare epoch
+    stamp_ts=$(grep -oE '^TS=[0-9]+' "$STAMP" | cut -d= -f2 || true)
+    [[ -z "$stamp_ts" ]] && stamp_ts=$(head -1 "$STAMP")
+    stamp_age=$(( $(date +%s) - ${stamp_ts:-0} ))
     [[ $stamp_age -lt $THRESHOLD ]] && exit 0
 fi
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -2,9 +2,11 @@
 """
 verify.py — MarkView full verification runner (replaces verify.sh).
 
-Runs every check tier in order and writes BOTH verify stamps on success:
-  - Per-repo:  <project>/.last-verify-at      (commit-gate primary)
-  - Global:    COMMIT_GATE_VERIFY_STAMP env    (commit-gate fallback)
+Runs every check tier in order and writes BOTH verify stamps on success
+(HA-008 format: "TIER=all\\nTS=<epoch>"):
+  - Per-repo:  <project>/.last-verify-at       (commit-gate per-repo fallback)
+  - Global:    COMMIT_GATE_VERIFY_STAMP env     (default: claude-repl-template
+               .claude/memory/.last-verify-at — commit-gate primary)
 
 Usage:
   python3 scripts/verify.py                   # standard tiers
@@ -30,7 +32,9 @@ APPEX_RSRC = (
 )
 INSTALLED_APP = Path("/Applications/MarkView.app")
 
-_GLOBAL_STAMP_DEFAULT = Path.home() / "repos/claude-loop/.claude/memory/.last-verify-at"
+_GLOBAL_STAMP_DEFAULT = (
+    Path.home() / "repos/claude-repl-template/.claude/memory/.last-verify-at"
+)
 GLOBAL_STAMP = Path(
     os.environ.get("COMMIT_GATE_VERIFY_STAMP", str(_GLOBAL_STAMP_DEFAULT))
 )
@@ -88,10 +92,12 @@ def run_filtered(cmd: list[str], cwd: Path = PROJECT_DIR) -> tuple[int, str]:
 
 
 def write_stamps() -> None:
-    ts = str(int(time.time())) + "\n"
-    PER_REPO_STAMP.write_text(ts)
+    # HA-008 tiered format: commit_gate.py requires TIER in {test, slow, all};
+    # bare-epoch stamps are no longer accepted.
+    stamp = f"TIER=all\nTS={int(time.time())}\n"
+    PER_REPO_STAMP.write_text(stamp)
     if GLOBAL_STAMP.parent.exists():
-        GLOBAL_STAMP.write_text(ts)
+        GLOBAL_STAMP.write_text(stamp)
     ok("Verify stamps written (per-repo + global, threshold=30m)")
 
 


### PR DESCRIPTION
The global commit gate (claude-repl-template hooks/commit_gate.py) is
retiring its legacy bare-epoch stamp clause. MarkView was the last
bare-epoch writer:

- verify.py: write_stamps() now emits "TIER=all\nTS=<epoch>"; global
  stamp default repointed from archived ~/repos/claude-loop (silent
  no-op since the archive) to ~/repos/claude-repl-template
- Makefile playwright target: stamp is now "TIER=test" (a real e2e run
  keeps satisfying the gate for render-critical commits, unchanged
  behavior)
- pre-commit-hook.sh + render-verify-gate.sh: parse TS= from the new
  format, fall back to legacy bare epoch; `|| true` guards the grep
  pipeline under set -euo pipefail

Verified: both formats parse under set -euo pipefail; commit_gate's
_parse_stamp() accepts TIER=all and TIER=test as sufficient.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
