### PR TITLE
ci: item-658 wall-clock optimization — SPM cache path fix, playwright cache, guard dedup, path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,12 @@ jobs:
         with:
           path: |
             .build
-            ~/.cache/org.swift.swiftpm
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+            ~/Library/Caches/org.swift.swiftpm
+          # v2: corrected SPM cache dir (~/Library/Caches on macOS; the old ~/.cache
+          # path is Linux-only and was never populated on these runners).
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-
             spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Build (debug)
@@ -77,9 +80,12 @@ jobs:
         with:
           path: |
             .build
-            ~/.cache/org.swift.swiftpm
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+            ~/Library/Caches/org.swift.swiftpm
+          # v2: corrected SPM cache dir (~/Library/Caches on macOS; the old ~/.cache
+          # path is Linux-only and was never populated on these runners).
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-
             spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run verification
@@ -97,9 +103,12 @@ jobs:
         with:
           path: |
             .build
-            ~/.cache/org.swift.swiftpm
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+            ~/Library/Caches/org.swift.swiftpm
+          # v2: corrected SPM cache dir (~/Library/Caches on macOS; the old ~/.cache
+          # path is Linux-only and was never populated on these runners).
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-
             spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install XcodeGen
@@ -129,9 +138,12 @@ jobs:
         with:
           path: |
             .build
-            ~/.cache/org.swift.swiftpm
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+            ~/Library/Caches/org.swift.swiftpm
+          # v2: corrected SPM cache dir (~/Library/Caches on macOS; the old ~/.cache
+          # path is Linux-only and was never populated on these runners).
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-
             spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run MCP protocol tests
@@ -149,9 +161,12 @@ jobs:
         with:
           path: |
             .build
-            ~/.cache/org.swift.swiftpm
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+            ~/Library/Caches/org.swift.swiftpm
+          # v2: corrected SPM cache dir (~/Library/Caches on macOS; the old ~/.cache
+          # path is Linux-only and was never populated on these runners).
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-
             spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Regenerate goldens
@@ -179,9 +194,12 @@ jobs:
         with:
           path: |
             .build
-            ~/.cache/org.swift.swiftpm
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+            ~/Library/Caches/org.swift.swiftpm
+          # v2: corrected SPM cache dir (~/Library/Caches on macOS; the old ~/.cache
+          # path is Linux-only and was never populated on these runners).
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-
             spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run visual smoke tests (non-blank render gate)

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -27,9 +27,13 @@ jobs:
       - name: Cache SPM dependencies
         uses: actions/cache@v4
         with:
-          path: .build
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          # Same key namespace as ci.yml so these jobs restore the cache CI just saved.
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-
             spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run fuzz tests (10,000 inputs)
@@ -46,9 +50,13 @@ jobs:
       - name: Cache SPM dependencies
         uses: actions/cache@v4
         with:
-          path: .build
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          # Same key namespace as ci.yml so these jobs restore the cache CI just saved.
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-
             spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run differential tests vs cmark-gfm

--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -1,5 +1,11 @@
 name: Repo Guard
-on: [push, pull_request]
+# push is limited to main — an unfiltered [push, pull_request] ran every guard job
+# twice per PR-branch push (push event + pull_request synchronize for the same commit).
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,6 +9,18 @@ on:
       - "Tests/TestRunner/Fixtures/**"
   pull_request:
     branches: [main]
+    # Same path filters as push — skips docs/npm-only PRs. Safe to filter:
+    # this is NOT a required status check (required: Build & Test, Golden Drift Check),
+    # so a skipped run cannot block auto-merge.
+    paths:
+      - "Sources/MarkViewCore/**"
+      - "Tests/playwright/**"
+      - "Tests/TestRunner/Fixtures/**"
+
+# Cancel superseded runs for the same branch/PR
+concurrency:
+  group: playwright-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   playwright:
@@ -24,15 +36,29 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-          cache-dependency-path: Tests/playwright/package.json
+          # Key on the lockfile (exact resolved versions), not package.json.
+          cache-dependency-path: Tests/playwright/package-lock.json
 
       - name: Install dependencies
         working-directory: Tests/playwright
         run: npm ci
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('Tests/playwright/package-lock.json') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: Tests/playwright
         run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright OS deps (browser cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: Tests/playwright
+        run: npx playwright install-deps chromium
 
       - name: Check fixtures are committed
         run: |


### PR DESCRIPTION
- SPM cache blocks cached the LINUX cache dir (~/.cache/org.swift.swiftpm)
  on macos-15 runners — never populated. Fixed to ~/Library/Caches/...,
  key bumped spm-v2 with fallback restore-key (no cold rebuild).
- playwright.yml: browser cache (~130MB Chromium skip on hit), npm cache
  keyed on package-lock.json (was package.json), concurrency
  cancel-in-progress, PR path filters (docs/npm-only PRs skip 2m31s job;
  branch-protection verified — required checks are Build & Test + Golden
  Drift only, so path-skip can't wedge auto-merge).
- guard.yml: [push, pull_request] ran every job twice per PR push; now
  push:main + pull_request:main. Frees a macOS runner slot (concurrency
  cap 5 = Bundle's 67s pickup latency in PR runs).
- extended.yml: cache aligned to v2 namespace so fuzz/diff restore CI's
  cache from the same commit.

Expected: ~30-60s typical, 2m31s eliminated on non-rendering PRs; Bundle
job (the remaining whale) documented as follow-up in
docs/personal/ci-optimization-658-2026-07-04.md (gitignored).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
