### PR TITLE
fix: don't count escaped pipes (\|) as table cell delimiters in lint

### DIFF
--- a/Sources/MarkViewCore/MarkdownLinter.swift
+++ b/Sources/MarkViewCore/MarkdownLinter.swift
@@ -466,9 +466,30 @@ public final class MarkdownLinter {
     }
 
     private func pipeCount(_ line: String) -> Int {
-        // Count cells by splitting on | and filtering empty edges
-        let parts = line.split(separator: "|", omittingEmptySubsequences: false)
-        // A line like "| a | b | c |" splits to ["", " a ", " b ", " c ", ""]
+        // Count cells by splitting on unescaped | only. Per the GFM table spec
+        // (https://github.github.com/gfm/#example-200), `\|` is a literal pipe
+        // inside a cell — even within backtick code spans — and must not count
+        // as a cell delimiter (issue #29). A backslash escapes the character
+        // that follows it, so `\\|` is a literal backslash followed by a real
+        // delimiter. A line like "| a | b | c |" yields ["", " a ", " b ", " c ", ""].
+        var parts: [String] = []
+        var current = ""
+        var escaped = false
+        for ch in line {
+            if escaped {
+                current.append(ch)
+                escaped = false
+            } else if ch == "\\" {
+                current.append(ch)
+                escaped = true
+            } else if ch == "|" {
+                parts.append(current)
+                current = ""
+            } else {
+                current.append(ch)
+            }
+        }
+        parts.append(current)
         return parts.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }.count
     }
 }

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1378,6 +1378,38 @@ runner.test("linter clean: consistent table columns") {
     try expect(diags.isEmpty, "Consistent tables should produce no diagnostics")
 }
 
+runner.test("linter clean: escaped pipe in table cell code span (issue #29)") {
+    let md = "| Action | Command                 |\n| ------ | ----------------------- |\n| Filter | `./program \\| grep foo` |\n"
+    let diags = linter.lint(md, rules: [.invalidTables])
+    try expect(diags.isEmpty, "Escaped pipe (\\|) in a cell must not count as a column delimiter, got: \(diags.map { $0.message })")
+}
+
+runner.test("linter clean: escaped pipe in table cell without backticks (issue #29)") {
+    let md = "| A | B |\n|---|---|\n| Filter | a \\| b |\n"
+    let diags = linter.lint(md, rules: [.invalidTables])
+    try expect(diags.isEmpty, "Escaped pipe outside a code span must not count as a column delimiter, got: \(diags.map { $0.message })")
+}
+
+runner.test("linter clean: escaped pipe in table header (issue #29)") {
+    let md = "| A \\| B | C |\n|---|---|\n| 1 | 2 |\n"
+    let diags = linter.lint(md, rules: [.invalidTables])
+    try expect(diags.isEmpty, "Escaped pipe in header must not count as a column delimiter, got: \(diags.map { $0.message })")
+}
+
+runner.test("linter: escaped backslash before pipe still delimits (issue #29)") {
+    // Markdown `\\|` is an escaped backslash followed by a real delimiter,
+    // so this row has 3 cells against a 2-column header.
+    let md = "| A | B |\n|---|---|\n| a \\\\| b | c |\n"
+    let diags = linter.lint(md, rules: [.invalidTables])
+    try expect(diags.count == 1, "Escaped backslash + pipe (\\\\|) must still delimit; expected 1 diagnostic, got \(diags.count)")
+}
+
+runner.test("linter still detects real column mismatch (issue #29 negative)") {
+    let md = "| A | B |\n|---|---|\n| 1 | 2 | 3 |\n"
+    let diags = linter.lint(md, rules: [.invalidTables])
+    try expect(diags.count == 1, "Genuine 3-vs-2 column mismatch must still be flagged, got \(diags.count)")
+}
+
 // Integration tests
 
 runner.test("linter diagnostics are sorted by line") {


### PR DESCRIPTION
## Summary

The `invalid-tables` lint rule split table rows on every `|` character, so GFM's `\|` escape — the only way to put a literal pipe inside a table cell, per the [GFM spec, example 200](https://github.github.com/gfm/#example-200) — was counted as a column delimiter. The repro from the issue:

```markdown
| Action | Command                 |
| ------ | ----------------------- |
| Filter | `./program \| grep foo` |
```

produced a false "Table row has 3 columns but header has 2 columns" warning.

## Fix

`pipeCount()` in `MarkdownLinter.swift` now splits on unescaped pipes only: a backslash escapes the character that follows it, so `\|` stays inside its cell while `\\|` (escaped backslash followed by a pipe) still delimits. Note that per the GFM spec backticks do NOT protect a pipe in a table row — only `\|` does — so escape-aware splitting (not code-span masking) is the spec-correct behavior for this rule.

## Tests

Written failing-first, confirmed reproducing the exact issue message before the fix:

- escaped pipe inside a code-span cell (exact issue repro)
- escaped pipe without backticks
- escaped pipe in the header row
- negative-corpus guards: `\\|` still delimits; genuine 3-vs-2 column mismatch is still flagged

`swift run MarkViewTestRunner`: 324 passed, 0 failed (was 321 passed / 3 failed before the fix). `python3 scripts/verify.py`: all checks passed.

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
