### PR TITLE
Release hardening: make version drift and publish-destination drift structurally impossible

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -49,6 +49,8 @@ jobs:
         run: |
           bash Tests/test-rule-gates.sh
           bash scripts/check-rule-gates.sh
+      - name: Verify single-owner publish destinations (only npm-publish.yml may publish)
+        run: python3 scripts/check_release_destinations.py
 
   check-ci-deps:
     runs-on: macos-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,11 @@ name: Publish npm
 # Use when only npm/ changes (JS module, package.json) and no new app binary is needed.
 # The postinstall continues to download the existing binary from the latest GitHub Release.
 #
-# Trigger: workflow_dispatch (manual) or automatic when npm/package.json changes on main.
+# Triggers: workflow_dispatch (manual), automatic when npm/ changes on main, and
+# workflow_run after a successful Release — a coordinated app+npm release fires the
+# push trigger before release.yml has uploaded the binary artifacts, so the publish
+# gate fails that first run and this retry completes the publish (idempotent via
+# the already-published check).
 #
 # Auth: npm Trusted Publishing (OIDC) — configured on the package's npm Settings for
 # this repo + this workflow filename. No NPM_TOKEN to expire (the 1.6.0 release was
@@ -27,6 +31,9 @@ on:
       - 'npm/index.js'
       - 'npm/scripts/**'
       - 'npm/bin/**'
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -34,7 +41,9 @@ env:
 jobs:
   publish:
     runs-on: macos-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+    # workflow_run retries only make sense after a SUCCESSFUL release.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       id-token: write   # npm Trusted Publishing + mcp-publisher github-oidc
@@ -66,6 +75,15 @@ jobs:
             echo "SKIP=false" >> $GITHUB_OUTPUT
             echo "mcp-server-markview@${VERSION} not yet published — proceeding"
           fi
+
+      - name: Gate — BINARY_VERSION current and its release asset downloadable
+        # npm publishes are immutable. Blocks the 1.6.0 incident class:
+        # a stale postinstall pin (old binary under a new package version)
+        # or a pin whose GitHub release / tar.gz asset does not exist yet.
+        if: steps.check.outputs.SKIP == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/npm_publish_gate.py
 
       - name: Install npm dependencies
         if: steps.check.outputs.SKIP == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Gate — version files must match the release tag
+        # Fails in seconds instead of shipping a mislabeled 60-90 min build.
+        # Strict mode: all six version-carrying files (both Info.plists, MCP
+        # main.swift, npm/package.json, npm/server.json, and postinstall.js
+        # BINARY_VERSION) must equal the tag being released. The 1.6.0 tag
+        # built and published while BINARY_VERSION still said 1.4.0.
+        if: startsWith(github.ref, 'refs/tags/')
+        run: python3 scripts/check_version_sync.py --expect-tag "${GITHUB_REF_NAME}"
+
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,9 +24,12 @@ Changes since v1.4.2 not yet shipped:
 - **Adoption floor**: Post-breakout organic baseline did NOT hold at 20-25/day. Current floor: 4-6/day.
 
 > **BINARY_VERSION contract**: `postinstall.js` BINARY_VERSION points to the last
-> successfully notarized GitHub Release binary. It is intentionally decoupled from
-> the npm package version. npm patches (JS wrapper changes) do NOT bump BINARY_VERSION.
-> Only run `release.sh --bump-binary` when a new notarized binary is published to GitHub.
+> successfully notarized GitHub Release binary. npm patches (JS wrapper changes) do
+> NOT bump BINARY_VERSION. App releases ALWAYS bump it: `release.sh --bump` updates
+> it with the other five version files (the old opt-in `--bump-binary` flag is how
+> the 1.6.0 stale-pin incident happened and was removed). Gates:
+> `check_version_sync.py` (staleness, PR guard), `check_version_sync.py --expect-tag`
+> (release.yml + preflight), `npm_publish_gate.py` (npm-publish.yml).
 
 ### v1.4.2 Changes (2026-04-08)
 - **KaTeX fix**: Removed `$...$` inline delimiter — was garbling financial prose (`$10,000`). Kept `$$...$$`, `\(...\)`, `\[...\]`.
@@ -241,6 +244,6 @@ See MOBILE.md for per-platform blocker lists and release plan.
 | `Sources/MarkViewMCPServer/main.swift` | MCP server: 3 tools + resources endpoint |
 | `Tests/TestRunner/Fixtures/golden-corpus.md` | Visual QA fixture — all features |
 | `scripts/metrics.sh` | Unified traction tracking |
-| `scripts/release.sh` | Release automation (`--ship`, `--bump-binary` flags) |
+| `scripts/release.sh` | Release automation (`--ship` flag; always bumps all 6 version files) |
 | `scripts/check-version-sync.sh` | Version contract verification |
 | `docs/personal/` | Strategy, adoption, competitive docs (gitignored) |

--- a/scripts/check_release_destinations.py
+++ b/scripts/check_release_destinations.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+check_release_destinations.py — enforce one owner per publish destination.
+
+The 1.6.0 incident had TWO npm publishers: release.yml published from the
+tag commit (before the BINARY_VERSION pin fix landed on main) while
+npm-publish.yml published from main. Two writers to one immutable registry
+guarantee that one of them eventually ships the wrong content. 744c8a7
+removed release.yml's publish step; this lint makes reintroducing it — in
+any workflow or in scripts/release.sh — a CI failure instead of a code
+review hope.
+
+Contract (comment lines are ignored):
+- `npm publish` may appear ONLY in .github/workflows/npm-publish.yml
+- `mcp-publisher publish` may appear ONLY in npm-publish.yml
+- NPM_TOKEN may appear NOWHERE (npm auth is OIDC trusted publishing)
+- npm-publish.yml itself must still contain `npm publish` and
+  `id-token: write` — if the single owner loses its publish step or its
+  OIDC grant, that is drift too.
+
+Usage:
+    python3 scripts/check_release_destinations.py
+
+Exit 0: destinations single-owned.  Exit 1: violation(s).
+
+Consumers:
+    .github/workflows/guard.yml   (CI gate; registered in rule-gates.json
+                                   as npm-publish-single-owner)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent
+
+OWNER = ".github/workflows/npm-publish.yml"
+
+PUBLISH_PATTERNS = {
+    "npm publish": re.compile(r"\bnpm\s+publish\b"),
+    "mcp-publisher publish": re.compile(r"\bmcp-publisher\s+publish\b"),
+}
+NPM_TOKEN_RE = re.compile(r"\bNPM_TOKEN\b")
+
+
+def significant_text(path: Path) -> str:
+    """File content with comment lines removed (first non-space char '#').
+
+    Covers YAML comments and comment lines inside `run: |` shell blocks —
+    prose ABOUT publishing stays legal; code that publishes does not.
+    """
+    try:
+        lines = path.read_text(errors="replace").splitlines()
+    except OSError:
+        return ""
+    return "\n".join(l for l in lines if not l.lstrip().startswith("#"))
+
+
+def run(project_dir: Path) -> int:
+    """Scan workflows + release.sh; print report; return exit code."""
+    workflows_dir = project_dir / ".github/workflows"
+    scanned = sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml"))
+    release_sh = project_dir / "scripts/release.sh"
+    if release_sh.is_file():
+        scanned.append(release_sh)
+
+    errors = 0
+    owner_seen = False
+
+    for path in scanned:
+        rel = path.relative_to(project_dir).as_posix()
+        text = significant_text(path)
+        is_owner = rel == OWNER
+        owner_seen = owner_seen or is_owner
+
+        for label, pattern in PUBLISH_PATTERNS.items():
+            if pattern.search(text) and not is_owner:
+                print(
+                    f"  ✗ {rel} contains '{label}' — publishing is owned "
+                    f"exclusively by {OWNER} (one owner per destination; "
+                    f"the 1.6.0 dual-publish incident)"
+                )
+                errors += 1
+
+        if NPM_TOKEN_RE.search(text):
+            print(
+                f"  ✗ {rel} references NPM_TOKEN — npm auth is OIDC trusted "
+                f"publishing only (tokens expire; 1.6.0 was blocked by one)"
+            )
+            errors += 1
+
+    # The single owner must still be doing its job.
+    owner_path = project_dir / OWNER
+    owner_text = significant_text(owner_path)
+    if not owner_seen or not owner_path.is_file():
+        print(f"  ✗ {OWNER} not found — npm publishing has no owner")
+        errors += 1
+    else:
+        if PUBLISH_PATTERNS["npm publish"].search(owner_text):
+            print(f"  ✓ {OWNER} owns 'npm publish'")
+        else:
+            print(f"  ✗ {OWNER} no longer contains 'npm publish' — owner lost")
+            errors += 1
+        if "id-token: write" in owner_text:
+            print(f"  ✓ {OWNER} keeps OIDC (id-token: write)")
+        else:
+            print(
+                f"  ✗ {OWNER} missing 'id-token: write' — OIDC trusted "
+                f"publishing requires it"
+            )
+            errors += 1
+
+    if errors:
+        print()
+        print(f"✗ Release destination check failed: {errors} violation(s)")
+        return 1
+
+    print(f"  ✓ No stray publishers in {len(scanned)} scanned file(s)")
+    print("✓ Publish destinations single-owned")
+    return 0
+
+
+def main() -> None:
+    sys.exit(run(PROJECT_DIR))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -6,17 +6,32 @@ The canonical version is read from Sources/MarkView/Info.plist.
 
 Usage:
     python3 scripts/check_version_sync.py
+    python3 scripts/check_version_sync.py --expect-tag vX.Y.Z   (strict release mode)
     bash scripts/check-version-sync.sh   (thin wrapper)
+
+Default mode (developer/PR guard): mid-release states are allowed (canonical
+bumped but not yet tagged), npm may run ahead for JS-only patches, but any
+*stale* version — a version-carrying file pointing at an older released
+version than it should — is an error. In particular BINARY_VERSION must be
+the highest released vX.Y.Z tag (the 1.6.0 incident shipped npm users the
+v1.4.0 binary because only tag *existence* was checked, not currency).
+
+--expect-tag mode (release gate): every version-carrying file must equal
+X.Y.Z exactly — including npm/package.json and BINARY_VERSION. Used by
+release.yml before building artifacts and by release_preflight.py before
+tagging.
 
 Exit 0: all versions in sync (warnings allowed).
 Exit 1: one or more mismatches (or canonical version unreadable).
+Exit 2: bad CLI usage.
 
 Consumers — keep stdout shape and exit code stable:
-    .github/workflows/guard.yml     exit code (CI gate)
+    .github/workflows/guard.yml     exit code (CI gate, default mode)
+    .github/workflows/release.yml   exit code (release gate, --expect-tag)
     scripts/verify.py               exit code (stdout re-printed)
     scripts/pre-commit-hook.sh      exit code only (output discarded)
     scripts/verify-release.sh       greps stdout for "✓ All versions in sync"
-    scripts/release_preflight.py    exit code only (output discarded)
+    scripts/release_preflight.py    exit code (strict --expect-tag mode)
 """
 
 from __future__ import annotations
@@ -98,6 +113,40 @@ def latest_version_tag(project_dir: Path) -> str:
     return tag[1:] if tag.startswith("v") else tag
 
 
+VERSION_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+def all_version_tags(project_dir: Path) -> list[str]:
+    """Every vX.Y.Z tag in the repo (unsorted); [] if none."""
+    out = _git(["tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"], project_dir)
+    return [t for t in out.splitlines() if VERSION_TAG_RE.match(t)]
+
+
+def _version_key(version: str) -> tuple[int, int, int]:
+    """Numeric sort key for 'X.Y.Z' or 'vX.Y.Z'; raises ValueError if malformed."""
+    major, minor, patch = version.removeprefix("v").split(".")
+    return (int(major), int(minor), int(patch))
+
+
+def highest_version_tag(tags: list[str]) -> str:
+    """Highest vX.Y.Z tag by numeric version order; '' if none.
+
+    Numeric, not lexicographic — 'v1.10.0' must beat 'v1.9.0'.
+    """
+    return max(tags, key=_version_key, default="")
+
+
+def _is_js_only_ahead(npm_ver: str, canonical: str, project_dir: Path) -> bool:
+    """True when npm_ver is a legitimate JS-only patch version: numerically
+    ahead of the app's canonical version AND without a corresponding app tag
+    (an app tag for it would mean the app moved on and npm was left behind)."""
+    try:
+        ahead = _version_key(npm_ver) > _version_key(canonical)
+    except ValueError:
+        return False  # malformed version — let the caller flag it
+    return ahead and not tag_exists(project_dir, f"v{npm_ver}")
+
+
 def tag_exists(project_dir: Path, tag: str) -> bool:
     """True if `git tag --list <tag>` returns output."""
     return bool(_git(["tag", "--list", tag], project_dir))
@@ -115,8 +164,12 @@ def commits_since(project_dir: Path, tag: str) -> int:
 # ── Main check ────────────────────────────────────────────────────────────────
 
 
-def run(project_dir: Path) -> int:
-    """Run every version-sync check; print report; return exit code."""
+def run(project_dir: Path, expect: str | None = None) -> int:
+    """Run every version-sync check; print report; return exit code.
+
+    `expect` (bare X.Y.Z) enables strict release mode: every version-carrying
+    file must equal it exactly — no mid-release allowances.
+    """
     plist = project_dir / "Sources/MarkView/Info.plist"
     canonical = plist_value(plist, "CFBundleShortVersionString")
     if not canonical:
@@ -128,34 +181,42 @@ def run(project_dir: Path) -> int:
 
     errors = 0
 
-    # Git tag ↔ plist version check (Tier 0: no AI, pure string comparison).
-    # During a release the plist is bumped BEFORE the tag is created; if the
-    # plist version has no tag yet (unreleased bump), warn instead of error.
-    latest_tag = latest_version_tag(project_dir)
-    canonical_tag_present = tag_exists(project_dir, f"v{canonical}")
-    if not latest_tag:
-        print("  ⚠ No version tags found — skipping tag sync check")
-    elif latest_tag == canonical:
-        print(f"  ✓ Git tag v{latest_tag} matches Info.plist {canonical}")
-    elif not canonical_tag_present:
-        # Plist was bumped but tag not yet created — expected mid-release.
-        print(
-            f"  ⚠ Info.plist is {canonical} but no tag v{canonical} exists yet "
-            f"(unreleased bump — run: git tag v{canonical} && git push --tags)"
-        )
+    if expect is not None:
+        print(f"Strict release mode: every version must equal {expect}")
+        if canonical == expect:
+            print(f"  ✓ Info.plist matches release version {expect}")
+        else:
+            print(f"  ✗ Info.plist is {canonical} but the release expects {expect}")
+            errors += 1
     else:
-        # Tag exists but doesn't match plist — genuine mismatch.
-        print(f"  ✗ Git tag v{latest_tag} does not match Info.plist {canonical}")
-        print("    Fix: bash scripts/release.sh --bump patch  (or major/minor)")
-        errors += 1
+        # Git tag ↔ plist version check (Tier 0: no AI, pure string comparison).
+        # During a release the plist is bumped BEFORE the tag is created; if the
+        # plist version has no tag yet (unreleased bump), warn instead of error.
+        latest_tag = latest_version_tag(project_dir)
+        canonical_tag_present = tag_exists(project_dir, f"v{canonical}")
+        if not latest_tag:
+            print("  ⚠ No version tags found — skipping tag sync check")
+        elif latest_tag == canonical:
+            print(f"  ✓ Git tag v{latest_tag} matches Info.plist {canonical}")
+        elif not canonical_tag_present:
+            # Plist was bumped but tag not yet created — expected mid-release.
+            print(
+                f"  ⚠ Info.plist is {canonical} but no tag v{canonical} exists yet "
+                f"(unreleased bump — run: git tag v{canonical} && git push --tags)"
+            )
+        else:
+            # Tag exists but doesn't match plist — genuine mismatch.
+            print(f"  ✗ Git tag v{latest_tag} does not match Info.plist {canonical}")
+            print("    Fix: bash scripts/release.sh --bump patch  (or major/minor)")
+            errors += 1
 
-    # Warn if commits exist since last tag (unreleased changes).
-    since = commits_since(project_dir, f"v{latest_tag}")
-    if since > 0:
-        print(
-            f"  ⚠ {since} commit(s) since v{latest_tag} — "
-            "consider bumping version before release"
-        )
+        # Warn if commits exist since last tag (unreleased changes).
+        since = commits_since(project_dir, f"v{latest_tag}")
+        if since > 0:
+            print(
+                f"  ⚠ {since} commit(s) since v{latest_tag} — "
+                "consider bumping version before release"
+            )
 
     # Quick Look Info.plist
     ql_plist = project_dir / "Sources/MarkViewQuickLook/Info.plist"
@@ -190,13 +251,34 @@ def run(project_dir: Path) -> int:
             errors += 1
 
     # npm/package.json and server.json: must match each other.
-    # npm version may be ahead of the Swift canonical version for JS-only patches.
+    # Default mode: npm may run AHEAD of the Swift canonical version for
+    # JS-only patches (a version with no corresponding vX.Y.Z app tag).
+    # It must never sit at an older released version, and in strict release
+    # mode it must equal the release version exactly.
     npm_pkg = project_dir / "npm/package.json"
     npm_server = project_dir / "npm/server.json"
     npm_ver = ""
     if npm_pkg.is_file():
         npm_ver = json_version(npm_pkg)
-        print(f"  ✓ npm/package.json: {npm_ver}")
+        if expect is not None:
+            if npm_ver == expect:
+                print(f"  ✓ npm/package.json: {npm_ver}")
+            else:
+                print(f"  ✗ npm/package.json: {npm_ver} (expected {expect})")
+                errors += 1
+        elif npm_ver == canonical:
+            print(f"  ✓ npm/package.json: {npm_ver}")
+        elif _is_js_only_ahead(npm_ver, canonical, project_dir):
+            print(
+                f"  ✓ npm/package.json: {npm_ver} "
+                f"(JS-only version ahead of app {canonical})"
+            )
+        else:
+            print(
+                f"  ✗ npm/package.json: {npm_ver} is stale "
+                f"(app canonical is {canonical} — bump npm with the release)"
+            )
+            errors += 1
     if npm_server.is_file():
         server_ver = json_version(npm_server)
         if server_ver == npm_ver:
@@ -208,19 +290,48 @@ def run(project_dir: Path) -> int:
             )
             errors += 1
 
-    # postinstall.js uses BINARY_VERSION (the macOS release to download), which
-    # is intentionally decoupled from the npm package version — JS-only npm
-    # patches don't require a new macOS binary release. Only verify it
-    # references a real tag.
+    # postinstall.js BINARY_VERSION (the macOS release to download) is
+    # decoupled from the npm package version — JS-only npm patches don't
+    # require a new macOS binary release. But it must be CURRENT, not merely
+    # existent: the 1.6.0 incident shipped npm users the v1.4.0 binary for
+    # 3 months because only tag existence was checked.
+    #   strict mode:  BINARY_VERSION == release version, no exceptions.
+    #   default mode: if its tag exists it must be the highest vX.Y.Z tag;
+    #                 if not, it must equal canonical (mid-release bump).
     postinstall = project_dir / "npm/scripts/postinstall.js"
     if postinstall.is_file():
         binary_ver = (
             extract_versions(postinstall.read_text(), BINARY_VERSION_PATTERN) or "?"
         )
-        if tag_exists(project_dir, f"v{binary_ver}"):
+        if expect is not None:
+            if binary_ver == expect:
+                print(f"  ✓ npm/scripts/postinstall.js BINARY_VERSION: {binary_ver}")
+            else:
+                print(
+                    f"  ✗ npm/scripts/postinstall.js BINARY_VERSION: {binary_ver} "
+                    f"(expected {expect} — releasing v{expect} publishes the "
+                    f"MarkView-{expect}.tar.gz this pin must point at)"
+                )
+                errors += 1
+        elif tag_exists(project_dir, f"v{binary_ver}"):
+            highest = highest_version_tag(all_version_tags(project_dir))
+            if highest and f"v{binary_ver}" != highest:
+                print(
+                    f"  ✗ npm/scripts/postinstall.js BINARY_VERSION: {binary_ver} "
+                    f"is STALE — newer release tag {highest} exists "
+                    f"(npm installs would get the old binary; the 1.6.0 incident)"
+                )
+                errors += 1
+            else:
+                print(
+                    f"  ✓ npm/scripts/postinstall.js BINARY_VERSION: {binary_ver} "
+                    f"(latest release tag)"
+                )
+        elif binary_ver == canonical:
             print(
-                f"  ✓ npm/scripts/postinstall.js BINARY_VERSION: {binary_ver} "
-                f"(tag v{binary_ver} exists)"
+                f"  ⚠ npm/scripts/postinstall.js BINARY_VERSION: {binary_ver} "
+                f"has no tag yet (unreleased bump — tagging v{canonical} "
+                f"will publish its binary)"
             )
         else:
             print(
@@ -250,7 +361,18 @@ def run(project_dir: Path) -> int:
 
 
 def main() -> None:
-    sys.exit(run(PROJECT_DIR))
+    expect: str | None = None
+    args = sys.argv[1:]
+    if args:
+        if args[0] == "--expect-tag" and len(args) == 2:
+            expect = args[1].removeprefix("v")
+            if not BARE_VERSION_RE.fullmatch(expect):
+                print(f"✗ --expect-tag must be vX.Y.Z or X.Y.Z (got: {args[1]})")
+                sys.exit(2)
+        else:
+            print("Usage: check_version_sync.py [--expect-tag vX.Y.Z]")
+            sys.exit(2)
+    sys.exit(run(PROJECT_DIR, expect))
 
 
 if __name__ == "__main__":

--- a/scripts/npm_publish_gate.py
+++ b/scripts/npm_publish_gate.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+npm_publish_gate.py — hard gate run by npm-publish.yml BEFORE `npm publish`.
+
+The 1.6.0 incident: npm published with postinstall.js pinned to the v1.4.0
+binary while the app released v1.6.0 — npm installs silently downloaded a
+3-month-old binary. npm publishes are immutable, so the pin must be proven
+current and downloadable before the package leaves the building.
+
+Invariants enforced (exit 1 on any violation):
+1. If a git tag v<npm version> exists, this is a coordinated app+npm
+   release: BINARY_VERSION must equal the npm version. Because the push to
+   main (which triggers npm-publish.yml) can land moments before the tag
+   push, the gate waits up to --tag-wait seconds for the tag to appear
+   before concluding the publish is JS-only.
+2. If no such tag exists (JS-only npm patch): BINARY_VERSION must equal the
+   latest published GitHub release tag — never an older one.
+3. Always: the GitHub release v<BINARY_VERSION> must exist and carry the
+   MarkView-<BINARY_VERSION>.tar.gz asset that postinstall.js downloads.
+   During a coordinated release this fails while release.yml is still
+   building — npm-publish.yml re-runs automatically via its workflow_run
+   trigger once the Release workflow succeeds.
+
+Usage:
+    python3 scripts/npm_publish_gate.py [--tag-wait SECONDS]
+
+Requires gh (authenticated; in Actions set GH_TOKEN on the step).
+Repo slug from $GITHUB_REPOSITORY, defaulting to paulhkang94/markview.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_REPO = "paulhkang94/markview"
+DEFAULT_TAG_WAIT_SECONDS = 180
+POLL_INTERVAL_SECONDS = 15
+
+# Same extraction contract as check_version_sync.py (scripts stay
+# self-contained — they deploy and run as single files).
+BINARY_VERSION_RE = re.compile(r'const BINARY_VERSION = "([0-9]+\.[0-9]+\.[0-9]+)"')
+
+
+# ── Subprocess boundary (module-level so tests can stub — never call real gh) ─
+
+
+def _run(cmd: list[str]) -> tuple[int, str, str]:
+    """Run a command; return (returncode, stdout, stderr). Never raises."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        return 127, "", str(exc)
+    return result.returncode, result.stdout, result.stderr
+
+
+def _sleep(seconds: float) -> None:
+    time.sleep(seconds)
+
+
+# ── GitHub readers (module-level so tests can stub) ───────────────────────────
+
+
+def remote_tag_exists(repo: str, tag: str) -> bool:
+    """True if refs/tags/<tag> exists on GitHub."""
+    rc, _, _ = _run(["gh", "api", f"repos/{repo}/git/ref/tags/{tag}"])
+    return rc == 0
+
+
+def release_assets(repo: str, tag: str) -> list[str] | None:
+    """Asset names of release <tag>; None if the release does not exist."""
+    rc, out, _ = _run(
+        ["gh", "api", f"repos/{repo}/releases/tags/{tag}", "--jq", ".assets[].name"]
+    )
+    if rc != 0:
+        return None
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def latest_release_tag(repo: str) -> str:
+    """Tag name of the latest published release (e.g. 'v1.6.0'); '' if none."""
+    rc, out, _ = _run(
+        ["gh", "api", f"repos/{repo}/releases/latest", "--jq", ".tag_name"]
+    )
+    return out.strip() if rc == 0 else ""
+
+
+# ── File readers ──────────────────────────────────────────────────────────────
+
+
+def read_npm_version(project_dir: Path) -> str:
+    try:
+        with open(project_dir / "npm/package.json") as f:
+            return str(json.load(f)["version"])
+    except Exception:
+        return ""
+
+
+def read_binary_version(project_dir: Path) -> str:
+    try:
+        text = (project_dir / "npm/scripts/postinstall.js").read_text()
+    except OSError:
+        return ""
+    match = BINARY_VERSION_RE.search(text)
+    return match.group(1) if match else ""
+
+
+# ── Gate ──────────────────────────────────────────────────────────────────────
+
+
+def run_gate(
+    project_dir: Path,
+    repo: str,
+    tag_wait_seconds: int = DEFAULT_TAG_WAIT_SECONDS,
+) -> int:
+    """Run every publish-gate check; print report; return exit code."""
+    npm_ver = read_npm_version(project_dir)
+    pin = read_binary_version(project_dir)
+    if not npm_ver:
+        print("✗ Cannot read version from npm/package.json")
+        return 1
+    if not pin:
+        print("✗ Cannot read BINARY_VERSION from npm/scripts/postinstall.js")
+        return 1
+
+    print(f"npm package version:      {npm_ver}")
+    print(f"postinstall BINARY_VERSION: {pin}")
+
+    if pin == npm_ver:
+        # Coordinated release shape — correctness reduces to the asset check.
+        print(f"  ✓ BINARY_VERSION matches the npm version ({pin})")
+    else:
+        # Is an app tag for this npm version present (or about to be)?
+        npm_tag = f"v{npm_ver}"
+        strict = remote_tag_exists(repo, npm_tag)
+        if not strict:
+            # A coordinated release pushes main (triggering this workflow)
+            # moments before the tag — wait so a stale pin can't slip
+            # through that gap and get published immutably.
+            waited = 0
+            while waited < tag_wait_seconds:
+                _sleep(POLL_INTERVAL_SECONDS)
+                waited += POLL_INTERVAL_SECONDS
+                if remote_tag_exists(repo, npm_tag):
+                    strict = True
+                    break
+            if not strict:
+                print(
+                    f"  ✓ No app tag {npm_tag} after {waited}s — "
+                    f"treating as a JS-only npm publish"
+                )
+        if strict:
+            print(
+                f"  ✗ STALE BINARY_VERSION: app tag {npm_tag} exists but "
+                f"postinstall pins {pin} — npm users would get the wrong "
+                f"binary (the 1.6.0 incident). Bump BINARY_VERSION to "
+                f"{npm_ver} before publishing."
+            )
+            return 1
+        latest = latest_release_tag(repo)
+        if not latest:
+            print("  ✗ No published GitHub release found — nothing to download")
+            return 1
+        if f"v{pin}" != latest:
+            print(
+                f"  ✗ STALE BINARY_VERSION: {pin} but the latest published "
+                f"release is {latest} — JS-only publishes must pin the "
+                f"current binary"
+            )
+            return 1
+        print(f"  ✓ BINARY_VERSION {pin} is the latest published release")
+
+    # The exact artifact postinstall.js downloads must already be public.
+    assets = release_assets(repo, f"v{pin}")
+    if assets is None:
+        print(
+            f"  ✗ GitHub release v{pin} does not exist (yet). If the Release "
+            f"workflow is still running, this workflow re-runs automatically "
+            f"via workflow_run when it succeeds."
+        )
+        return 1
+    archive = f"MarkView-{pin}.tar.gz"
+    if archive not in assets:
+        print(
+            f"  ✗ Release v{pin} exists but has no {archive} asset — "
+            f"postinstall would fail for every npm install"
+        )
+        return 1
+    print(f"  ✓ Release v{pin} carries {archive}")
+
+    print("✓ npm publish gate passed")
+    return 0
+
+
+def main() -> None:
+    tag_wait = DEFAULT_TAG_WAIT_SECONDS
+    args = sys.argv[1:]
+    if args:
+        if args[0] == "--tag-wait" and len(args) == 2 and args[1].isdigit():
+            tag_wait = int(args[1])
+        else:
+            print("Usage: npm_publish_gate.py [--tag-wait SECONDS]")
+            sys.exit(2)
+    repo = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO)
+    sys.exit(run_gate(PROJECT_DIR, repo, tag_wait))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,6 @@ BUMP="patch"
 SKIP_TESTS=false
 DO_NOTARIZE=false
 SHIP=false        # --ship: auto-commit, tag, and push after a successful build
-BUMP_BINARY=false # --bump-binary: also update BINARY_VERSION in postinstall.js (only when new notarized binary is ready)
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -28,10 +27,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --notarize)
             DO_NOTARIZE=true
-            shift
-            ;;
-        --bump-binary)
-            BUMP_BINARY=true
             shift
             ;;
         --ship)
@@ -117,16 +112,13 @@ fs.writeFileSync('$NPM_SERVER', JSON.stringify(p, null, 2) + '\n');
     echo "Updated npm/server.json"
 fi
 if [ -f "$NPM_POSTINSTALL" ]; then
-    # BINARY_VERSION is intentionally decoupled from the npm package version:
-    # it points to the last GitHub Release that has a valid notarized binary.
-    # Only update it when --bump-binary is passed (i.e. a new Swift binary was built).
+    # BINARY_VERSION always bumps with an app release: tagging vNEW_VERSION is
+    # exactly what publishes the MarkView-NEW_VERSION.tar.gz this pin points at.
+    # The old opt-in --bump-binary flag is how the 1.6.0 incident happened —
+    # the default path left npm users pinned to a 3-month-old binary.
     # The variable name is BINARY_VERSION, not VERSION — keep the sed pattern aligned.
-    if [[ "${BUMP_BINARY:-false}" == "true" ]]; then
-        sed -i '' "s/const BINARY_VERSION = \"[0-9]*\.[0-9]*\.[0-9]*\";/const BINARY_VERSION = \"$NEW_VERSION\";/" "$NPM_POSTINSTALL"
-        echo "Updated npm/scripts/postinstall.js BINARY_VERSION → $NEW_VERSION"
-    else
-        echo "  ℹ Skipping BINARY_VERSION update (pass --bump-binary to update the binary pointer)"
-    fi
+    sed -i '' "s/const BINARY_VERSION = \"[0-9]*\.[0-9]*\.[0-9]*\";/const BINARY_VERSION = \"$NEW_VERSION\";/" "$NPM_POSTINSTALL"
+    echo "Updated npm/scripts/postinstall.js BINARY_VERSION → $NEW_VERSION"
 fi
 
 # Step 5: Run tests (unless --skip-tests)
@@ -195,42 +187,14 @@ else
     echo "WARNING: Dark mode CSS NOT found in binary"
 fi
 
-# Step 11: npm — create tar.gz artifact, upload to GitHub release, publish to npm
-# The tar.gz is needed by postinstall.js to extract the MCP server binary.
-# Structure: ./MarkView.app/Contents/MacOS/markview-mcp-server
-if [ -f "$NPM_PKG" ]; then
-    NPM_BINARY="/Applications/MarkView.app/Contents/MacOS/markview-mcp-server"
-    NPM_ARCHIVE="/tmp/MarkView-${NEW_VERSION}.tar.gz"
-
-    if [ -f "$NPM_BINARY" ]; then
-        echo ""
-        echo "--- Building npm release artifact ---"
-        _tmp_pkg="$(mktemp -d)"
-        mkdir -p "$_tmp_pkg/MarkView.app/Contents/MacOS"
-        cp "$NPM_BINARY" "$_tmp_pkg/MarkView.app/Contents/MacOS/"
-        tar -czf "$NPM_ARCHIVE" -C "$_tmp_pkg" MarkView.app/Contents/MacOS/markview-mcp-server
-        rm -rf "$_tmp_pkg"
-        echo "Created: $NPM_ARCHIVE ($(du -sh "$NPM_ARCHIVE" | cut -f1))"
-
-        # Upload to GitHub release if tag exists
-        if git tag --list "v$NEW_VERSION" | grep -q "v$NEW_VERSION"; then
-            echo "Uploading to GitHub release v$NEW_VERSION..."
-            gh release upload "v$NEW_VERSION" "$NPM_ARCHIVE" --repo paulhkang94/markview 2>&1 || \
-                echo "  ⚠ Upload failed — upload manually: gh release upload v$NEW_VERSION $NPM_ARCHIVE"
-        else
-            echo "  ⚠ Tag v$NEW_VERSION not found — create tag first, then run: gh release upload v$NEW_VERSION $NPM_ARCHIVE"
-        fi
-
-        # Publish to npm
-        echo "Publishing mcp-server-markview@$NEW_VERSION to npm..."
-        cd "$PROJECT_DIR/npm" && npm publish --access public 2>&1
-        cd "$PROJECT_DIR"
-        echo "Published to npm ✓"
-    else
-        echo "  ⚠ MCP server binary not found at $NPM_BINARY — skipping npm publish"
-        echo "    Build the app first with: bash scripts/bundle.sh --install"
-    fi
-fi
+# Step 11 (REMOVED — one owner per publish destination):
+# This script used to build the npm tar.gz, upload it to the GitHub release,
+# and run `npm publish` — a second publish path alongside CI. That dual
+# ownership is how npm 1.6.0 shipped pinned to the v1.4.0 binary.
+#   - release.yml owns the release artifacts (zip + tar.gz) on tag push
+#   - npm-publish.yml owns npm + MCP registry publishing (OIDC), gated by
+#     scripts/npm_publish_gate.py
+# scripts/check_release_destinations.py enforces this in CI.
 
 # Step 12: Commit, tag, push (--ship) or print manual instructions
 echo ""

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -11,7 +11,13 @@ Pass: prints "Pre-flight passed. Safe to tag.", writes the sentinel
 Fail: exits 1 with specific failure messages.
 
 Catches the 4-tag-push class of CI failures (missing secrets, wrong
-permissions, stale SPM cache) before any CI runner time is spent.
+permissions, stale SPM cache) before any CI runner time is spent, plus the
+1.6.0 class of version drift BEFORE the tag exists: strict version sync
+(check_version_sync.py --expect-tag — BINARY_VERSION included, FAIL not
+WARN), clean working tree, branch == main, tag non-existence (local and
+remote), a CHANGELOG entry for the release, and no npm version collision
+(a version already on the registry makes npm-publish.yml skip, leaving npm
+users pinned to the previous binary).
 
 Contract: the pre-push hook blocks `git push origin vX.Y.Z` unless the
 sentinel .release-preflight-passed-X.Y.Z exists at the repo root, and
@@ -125,6 +131,71 @@ def run_preflight() -> int:
     print("=== MarkView Release Pre-flight Check ===")
     print()
 
+    # ── 0. Release state: version, tree, branch, tag, changelog, npm ─────────
+    version = _plist_version(info_plist)
+    if version:
+        ok(f"Release version (Info.plist): {version}")
+    else:
+        fail("Cannot read CFBundleShortVersionString from Info.plist")
+
+    # Clean working tree — an uncommitted fix would not be in the tag commit
+    # (the 1.6.0 pin fix landed on main AFTER the tag was cut).
+    rc, status_out, _ = _run(["git", "status", "--porcelain"], cwd=PROJECT_DIR)
+    if rc == 0 and not status_out.strip():
+        ok("Working tree clean")
+    else:
+        fail("Working tree dirty — commit or stash before tagging")
+
+    rc, branch_out, _ = _run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=PROJECT_DIR
+    )
+    branch = branch_out.strip()
+    if rc == 0 and branch == "main":
+        ok("On branch main")
+    else:
+        fail(f"On branch '{branch}' — releases are tagged from main only")
+
+    if version:
+        _, local_tag, _ = _run(["git", "tag", "--list", f"v{version}"], cwd=PROJECT_DIR)
+        _, remote_tag, _ = _run(
+            ["git", "ls-remote", "--tags", "origin", f"refs/tags/v{version}"],
+            cwd=PROJECT_DIR,
+        )
+        if local_tag.strip() or remote_tag.strip():
+            fail(f"Tag v{version} already exists — bump the version first")
+        else:
+            ok(f"Tag v{version} does not exist yet (local + remote)")
+
+        try:
+            changelog_text = (PROJECT_DIR / "CHANGELOG.md").read_text()
+        except OSError:
+            changelog_text = ""
+        if f"## v{version}" in changelog_text:
+            ok(f"CHANGELOG.md documents v{version}")
+        else:
+            fail(
+                f"CHANGELOG.md has no '## v{version}' entry — "
+                "document the release before tagging"
+            )
+
+        # npm version collision: npm-publish.yml skips versions that are
+        # already on the registry, so a collision would leave npm users
+        # pinned to the previous binary forever.
+        if _which("npm"):
+            rc, npm_out, _ = _run(
+                ["npm", "view", f"mcp-server-markview@{version}", "version"],
+                cwd=PROJECT_DIR,
+            )
+            if rc == 0 and npm_out.strip() == version:
+                fail(
+                    f"mcp-server-markview@{version} is already published — "
+                    "npm-publish.yml would skip it; bump to an unpublished version"
+                )
+            else:
+                ok(f"npm version {version} is unpublished")
+        else:
+            warn("npm CLI not found — cannot verify npm version collision")
+
     # ── 1. GitHub CLI available ───────────────────────────────────────────────
     if _which("gh"):
         _, version_out, _ = _run(["gh", "--version"])
@@ -206,16 +277,24 @@ def run_preflight() -> int:
     else:
         fail("Local tests failing — fix before tagging")
 
-    # ── 8. Version consistency ────────────────────────────────────────────────
+    # ── 8. Version consistency (STRICT — the 1.6.0 gate) ─────────────────────
+    # WARN-level sync is what let 1.6.0 tag with a stale BINARY_VERSION.
+    # Strict mode: every version-carrying file (both Info.plists, MCP
+    # main.swift, npm/package.json, npm/server.json, BINARY_VERSION) must
+    # equal the version about to be tagged.
     print()
     version_sync = PROJECT_DIR / "scripts/check_version_sync.py"
     if version_sync.is_file():
-        rc, _, _ = _run([sys.executable, str(version_sync)], cwd=PROJECT_DIR)
+        rc, _, _ = _run(
+            [sys.executable, str(version_sync), "--expect-tag", f"v{version}"],
+            cwd=PROJECT_DIR,
+        )
         if rc == 0:
-            ok("Version numbers in sync")
+            ok(f"Version numbers in sync (strict — all files equal {version})")
         else:
-            warn(
-                "Version sync check failed — verify version numbers match across files"
+            fail(
+                "Version sync FAILED — see: python3 scripts/check_version_sync.py "
+                f"--expect-tag v{version} (BINARY_VERSION must match the release)"
             )
 
     # ── 9. Distribution path test ─────────────────────────────────────────────
@@ -240,7 +319,7 @@ def run_preflight() -> int:
     print("==================================================")
     if failures == 0:
         # Write sentinel consumed by the pre-push hook — proves this check ran.
-        version = _plist_version(info_plist) or "unknown"
+        version = version or "unknown"
         sentinel = PROJECT_DIR / f".release-preflight-passed-{version}"
         sentinel.touch()
         print(f"{green}Pre-flight passed. Safe to tag.{reset}")

--- a/scripts/rule-gates.json
+++ b/scripts/rule-gates.json
@@ -113,6 +113,14 @@
       "ci_pattern": "check_release_destinations\\.py",
       "gate_type": "script_run",
       "tier": 1
+    },
+    {
+      "id": "release-build-gated-on-version-sync",
+      "description": "release.yml must verify all six version-carrying files equal the pushed tag (check_version_sync.py --expect-tag) BEFORE building — tagging a commit with stale or unbumped files otherwise ships a mislabeled 60-90 min build (1.6.0 built with BINARY_VERSION still at 1.4.0).",
+      "ci_files": [".github/workflows/release.yml"],
+      "ci_pattern": "check_version_sync\\.py --expect-tag",
+      "gate_type": "script_run",
+      "tier": 1
     }
   ]
 }

--- a/scripts/rule-gates.json
+++ b/scripts/rule-gates.json
@@ -105,6 +105,14 @@
       "ci_pattern": "npm_publish_gate\\.py",
       "gate_type": "script_run",
       "tier": 1
+    },
+    {
+      "id": "npm-publish-single-owner",
+      "description": "npm publishing is owned exclusively by npm-publish.yml (OIDC). check_release_destinations.py fails CI if 'npm publish', 'mcp-publisher publish', or NPM_TOKEN reappears in release.yml, any other workflow, or release.sh — the 1.6.0 mispublish came from release.yml's duplicate token-based publish racing the pin fix on main.",
+      "ci_files": [".github/workflows/guard.yml"],
+      "ci_pattern": "check_release_destinations\\.py",
+      "gate_type": "script_run",
+      "tier": 1
     }
   ]
 }

--- a/scripts/rule-gates.json
+++ b/scripts/rule-gates.json
@@ -97,6 +97,14 @@
       "ci_pattern": "check-rule-gates\\.sh",
       "gate_type": "script_run",
       "tier": 1
+    },
+    {
+      "id": "npm-binary-pin-gated-at-publish",
+      "description": "npm-publish.yml must run npm_publish_gate.py before publishing: BINARY_VERSION must be current (not merely an existing tag) and its release tar.gz downloadable. npm publishes are immutable — the 1.6.0 incident shipped a 3-month-old binary because no such gate existed.",
+      "ci_files": [".github/workflows/npm-publish.yml"],
+      "ci_pattern": "npm_publish_gate\\.py",
+      "gate_type": "script_run",
+      "tier": 1
     }
   ]
 }

--- a/scripts/test-release-scripts.py
+++ b/scripts/test-release-scripts.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Tests for release_preflight.py, check_version_sync.py, and tap_audit.py.
+Tests for release_preflight.py, check_version_sync.py, tap_audit.py,
+npm_publish_gate.py, and check_release_destinations.py.
 
 Tier 2 behavioral tests — verify check logic, marker-file contract, and
 output/exit-code shape against fixture temp trees. All subprocess and
-network boundaries are stubbed: no live gh, git, swift, or HTTP calls.
+network boundaries are stubbed: no live gh, git, npm, swift, or HTTP calls.
 
 Usage:
     python3 scripts/test-release-scripts.py
@@ -671,6 +672,139 @@ class TestTapAudit(unittest.TestCase):
             code, output = self._run_main(mod)
         self.assertEqual(code, 1)
         self.assertIn("ERROR: could not fetch tap cask from", output)
+
+
+# ── check_release_destinations ────────────────────────────────────────────────
+
+
+OWNER_YML = (
+    "permissions:\n"
+    "  id-token: write\n"
+    "steps:\n"
+    "  - run: npm publish --access public\n"
+    "  - run: mcp-publisher publish\n"
+)
+
+
+class TestReleaseDestinations(unittest.TestCase):
+    def _make_repo(
+        self,
+        tmp: Path,
+        *,
+        owner_yml: str = OWNER_YML,
+        release_yml: str = "steps:\n  - run: echo build\n",
+        release_sh: str = "#!/bin/bash\necho build only\n",
+        extra_workflows: dict[str, str] | None = None,
+    ) -> None:
+        workflows = tmp / ".github/workflows"
+        workflows.mkdir(parents=True, exist_ok=True)
+        (workflows / "npm-publish.yml").write_text(owner_yml)
+        (workflows / "release.yml").write_text(release_yml)
+        for name, content in (extra_workflows or {}).items():
+            (workflows / name).write_text(content)
+        (tmp / "scripts").mkdir(exist_ok=True)
+        (tmp / "scripts/release.sh").write_text(release_sh)
+
+    def _run(self, tmp: Path) -> tuple[int, str]:
+        mod = _load("check_release_destinations")
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            rc = mod.run(tmp)
+        return rc, out.getvalue()
+
+    def test_single_owner_passes(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_repo(tmp)
+            rc, output = self._run(tmp)
+        self.assertEqual(rc, 0)
+        self.assertIn("✓ .github/workflows/npm-publish.yml owns 'npm publish'", output)
+        self.assertIn("✓ Publish destinations single-owned", output)
+
+    def test_npm_publish_in_release_yml_fails(self):
+        # The exact edit that caused the 1.6.0 mispublish, replayed.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_repo(
+                tmp,
+                release_yml="steps:\n  - run: cd npm && npm publish\n",
+            )
+            rc, output = self._run(tmp)
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ .github/workflows/release.yml contains 'npm publish'", output)
+        self.assertIn("1.6.0 dual-publish incident", output)
+
+    def test_npm_publish_in_release_sh_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_repo(
+                tmp,
+                release_sh="#!/bin/bash\ncd npm && npm publish --access public\n",
+            )
+            rc, output = self._run(tmp)
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ scripts/release.sh contains 'npm publish'", output)
+
+    def test_comment_mentions_are_ignored(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_repo(
+                tmp,
+                release_yml=(
+                    "# This workflow must never run npm publish (see 1.6.0).\n"
+                    "steps:\n"
+                    "  - run: echo build\n"
+                    "    # do not add npm publish here\n"
+                ),
+                release_sh=("#!/bin/bash\n# npm publish moved to npm-publish.yml\n"),
+            )
+            rc, _ = self._run(tmp)
+        self.assertEqual(rc, 0)
+
+    def test_npm_token_anywhere_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_repo(
+                tmp,
+                extra_workflows={
+                    "ci.yml": "env:\n  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}\n"
+                },
+            )
+            rc, output = self._run(tmp)
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ .github/workflows/ci.yml references NPM_TOKEN", output)
+
+    def test_owner_losing_publish_step_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_repo(
+                tmp,
+                owner_yml="permissions:\n  id-token: write\nsteps: []\n",
+            )
+            rc, output = self._run(tmp)
+        self.assertEqual(rc, 1)
+        self.assertIn("no longer contains 'npm publish' — owner lost", output)
+
+    def test_owner_losing_oidc_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_repo(
+                tmp,
+                owner_yml="steps:\n  - run: npm publish --access public\n",
+            )
+            rc, output = self._run(tmp)
+        self.assertEqual(rc, 1)
+        self.assertIn("missing 'id-token: write'", output)
+
+    def test_second_publisher_workflow_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_repo(
+                tmp,
+                extra_workflows={"sneaky.yml": "steps:\n  - run: npm  publish\n"},
+            )
+            rc, output = self._run(tmp)
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ .github/workflows/sneaky.yml contains 'npm publish'", output)
 
 
 # ── npm_publish_gate ──────────────────────────────────────────────────────────

--- a/scripts/test-release-scripts.py
+++ b/scripts/test-release-scripts.py
@@ -673,6 +673,189 @@ class TestTapAudit(unittest.TestCase):
         self.assertIn("ERROR: could not fetch tap cask from", output)
 
 
+# ── npm_publish_gate ──────────────────────────────────────────────────────────
+
+
+class TestNpmPublishGate(unittest.TestCase):
+    REPO = "paulhkang94/markview"
+
+    def _make_npm(self, tmp: Path, *, npm_ver: str, binary_ver: str) -> None:
+        (tmp / "npm/scripts").mkdir(parents=True, exist_ok=True)
+        (tmp / "npm/package.json").write_text(json.dumps({"version": npm_ver}))
+        (tmp / "npm/scripts/postinstall.js").write_text(
+            f'const BINARY_VERSION = "{binary_ver}";\n'
+        )
+
+    @contextlib.contextmanager
+    def _stubbed(
+        self,
+        mod,
+        *,
+        remote_tags: set[str] | None = None,
+        tags_after_wait: set[str] | None = None,
+        releases: dict[str, list[str]] | None = None,
+        latest: str = "",
+    ):
+        """Stub the GitHub + sleep boundaries.
+
+        `remote_tags` are visible immediately; `tags_after_wait` become
+        visible only after the first _sleep call (models the coordinated-
+        release race where the tag push trails the main push).
+        """
+        remote_tags = remote_tags or set()
+        tags_after_wait = tags_after_wait or set()
+        releases = releases or {}
+        sleeps: list[float] = []
+        visible = set(remote_tags)
+
+        def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+            visible.update(tags_after_wait)
+
+        with (
+            patch.object(mod, "remote_tag_exists", new=lambda r, t: t in visible),
+            patch.object(mod, "release_assets", new=lambda r, t: releases.get(t)),
+            patch.object(mod, "latest_release_tag", new=lambda r: latest),
+            patch.object(mod, "_sleep", new=fake_sleep),
+            patch("sys.stdout", new_callable=StringIO) as out,
+        ):
+            yield out, sleeps
+
+    def test_coordinated_release_with_asset_passes(self):
+        mod = _load("npm_publish_gate")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_npm(tmp, npm_ver="1.7.0", binary_ver="1.7.0")
+            with self._stubbed(
+                mod,
+                remote_tags={"v1.7.0"},
+                releases={"v1.7.0": ["MarkView-1.7.0.zip", "MarkView-1.7.0.tar.gz"]},
+            ) as (out, sleeps):
+                rc = mod.run_gate(tmp, self.REPO)
+        output = out.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("✓ BINARY_VERSION matches the npm version (1.7.0)", output)
+        self.assertIn("✓ Release v1.7.0 carries MarkView-1.7.0.tar.gz", output)
+        self.assertIn("✓ npm publish gate passed", output)
+        self.assertEqual(sleeps, [])  # pin == npm version: no tag wait needed
+
+    def test_release_still_building_fails_with_retry_hint(self):
+        # Coordinated release: main push triggered npm-publish before
+        # release.yml finished uploading artifacts.
+        mod = _load("npm_publish_gate")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_npm(tmp, npm_ver="1.7.0", binary_ver="1.7.0")
+            with self._stubbed(mod, remote_tags={"v1.7.0"}, releases={}) as (
+                out,
+                _,
+            ):
+                rc = mod.run_gate(tmp, self.REPO)
+        output = out.getvalue()
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ GitHub release v1.7.0 does not exist (yet)", output)
+        self.assertIn("re-runs automatically", output)
+
+    def test_stale_pin_with_app_tag_fails(self):
+        # THE 1.6.0 replay at the publish boundary: npm 1.6.0 about to
+        # publish while postinstall still pins 1.4.0 and tag v1.6.0 exists.
+        mod = _load("npm_publish_gate")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_npm(tmp, npm_ver="1.6.0", binary_ver="1.4.0")
+            with self._stubbed(
+                mod,
+                remote_tags={"v1.4.0", "v1.6.0"},
+                releases={"v1.4.0": ["MarkView-1.4.0.tar.gz"]},
+                latest="v1.6.0",
+            ) as (out, _):
+                rc = mod.run_gate(tmp, self.REPO)
+        output = out.getvalue()
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ STALE BINARY_VERSION: app tag v1.6.0 exists", output)
+        self.assertIn("the 1.6.0 incident", output)
+
+    def test_stale_pin_catches_tag_arriving_during_wait(self):
+        # Race shape: main push fires the workflow, tag push lands seconds
+        # later. The gate must wait for the tag instead of concluding
+        # "JS-only" and letting the stale pin publish immutably.
+        mod = _load("npm_publish_gate")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_npm(tmp, npm_ver="1.7.0", binary_ver="1.6.0")
+            with self._stubbed(
+                mod,
+                tags_after_wait={"v1.7.0"},
+                releases={"v1.6.0": ["MarkView-1.6.0.tar.gz"]},
+                latest="v1.6.0",
+            ) as (out, sleeps):
+                rc = mod.run_gate(tmp, self.REPO, tag_wait_seconds=60)
+        output = out.getvalue()
+        self.assertEqual(rc, 1)
+        self.assertGreaterEqual(len(sleeps), 1)
+        self.assertIn("✗ STALE BINARY_VERSION: app tag v1.7.0 exists", output)
+
+    def test_js_only_publish_with_current_pin_passes(self):
+        # npm 1.6.2 (no app tag), pin 1.6.0 == latest release: legitimate.
+        mod = _load("npm_publish_gate")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_npm(tmp, npm_ver="1.6.2", binary_ver="1.6.0")
+            with self._stubbed(
+                mod,
+                releases={"v1.6.0": ["MarkView-1.6.0.tar.gz"]},
+                latest="v1.6.0",
+            ) as (out, sleeps):
+                rc = mod.run_gate(tmp, self.REPO, tag_wait_seconds=30)
+        output = out.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertGreaterEqual(len(sleeps), 1)  # waited before deciding JS-only
+        self.assertIn("treating as a JS-only npm publish", output)
+        self.assertIn("✓ BINARY_VERSION 1.6.0 is the latest published release", output)
+
+    def test_js_only_publish_with_stale_pin_fails(self):
+        mod = _load("npm_publish_gate")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_npm(tmp, npm_ver="1.6.2", binary_ver="1.4.0")
+            with self._stubbed(
+                mod,
+                releases={"v1.4.0": ["MarkView-1.4.0.tar.gz"]},
+                latest="v1.6.0",
+            ) as (out, _):
+                rc = mod.run_gate(tmp, self.REPO, tag_wait_seconds=30)
+        output = out.getvalue()
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "✗ STALE BINARY_VERSION: 1.4.0 but the latest published release is v1.6.0",
+            output,
+        )
+
+    def test_release_missing_tarball_asset_fails(self):
+        mod = _load("npm_publish_gate")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_npm(tmp, npm_ver="1.7.0", binary_ver="1.7.0")
+            with self._stubbed(
+                mod,
+                remote_tags={"v1.7.0"},
+                releases={"v1.7.0": ["MarkView-1.7.0.zip"]},
+            ) as (out, _):
+                rc = mod.run_gate(tmp, self.REPO)
+        output = out.getvalue()
+        self.assertEqual(rc, 1)
+        self.assertIn("has no MarkView-1.7.0.tar.gz asset", output)
+
+    def test_unreadable_inputs_fail(self):
+        mod = _load("npm_publish_gate")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)  # no npm/ tree at all
+            with self._stubbed(mod) as (out, _):
+                rc = mod.run_gate(tmp, self.REPO)
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ Cannot read version from npm/package.json", out.getvalue())
+
+
 # ── Thin wrappers + wiring ────────────────────────────────────────────────────
 
 

--- a/scripts/test-release-scripts.py
+++ b/scripts/test-release-scripts.py
@@ -101,9 +101,11 @@ class TestVersionSync(unittest.TestCase):
         existing_tags: set[str],
         commits: int = 0,
     ):
+        version_tags = [t for t in existing_tags if mod.VERSION_TAG_RE.match(t)]
         with (
             patch.object(mod, "latest_version_tag", new=lambda pd: latest_tag),
             patch.object(mod, "tag_exists", new=lambda pd, tag: tag in existing_tags),
+            patch.object(mod, "all_version_tags", new=lambda pd: version_tags),
             patch.object(mod, "commits_since", new=lambda pd, tag: commits),
             patch.object(mod, "INSTALLED_PLIST", tmp / "not-installed.plist"),
             patch("sys.stdout", new_callable=StringIO) as out,
@@ -198,6 +200,160 @@ class TestVersionSync(unittest.TestCase):
                 rc = mod.run(tmp)
         self.assertEqual(rc, 1)
         self.assertIn("✗ Cannot read version from Info.plist", out.getvalue())
+
+    def test_stale_binary_version_fails(self):
+        # THE 1.6.0 incident: app released v1.6.0 but postinstall still pins
+        # v1.4.0. Old check passed (tag v1.4.0 exists); new check must fail.
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, canonical="1.6.0", binary_ver="1.4.0")
+            with self._stubbed(
+                mod, tmp, latest_tag="1.6.0", existing_tags={"v1.4.0", "v1.6.0"}
+            ) as out:
+                rc = mod.run(tmp)
+        output = out.getvalue()
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "✗ npm/scripts/postinstall.js BINARY_VERSION: 1.4.0 is STALE — "
+            "newer release tag v1.6.0 exists",
+            output,
+        )
+        self.assertNotIn("✓ All versions in sync", output)
+
+    def test_binary_version_staleness_sorts_numerically(self):
+        # v1.10.0 must beat v1.9.0 — lexicographic sort would invert this.
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, canonical="1.10.0", binary_ver="1.9.0")
+            with self._stubbed(
+                mod, tmp, latest_tag="1.10.0", existing_tags={"v1.9.0", "v1.10.0"}
+            ) as out:
+                rc = mod.run(tmp)
+        self.assertEqual(rc, 1)
+        self.assertIn("BINARY_VERSION: 1.9.0 is STALE", out.getvalue())
+
+    def test_binary_version_mid_release_bump_warns(self):
+        # Bump-all commit before tagging: pin == canonical, tag not yet pushed.
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, canonical="1.7.0", binary_ver="1.7.0")
+            with self._stubbed(
+                mod, tmp, latest_tag="1.6.0", existing_tags={"v1.6.0"}
+            ) as out:
+                rc = mod.run(tmp)
+        output = out.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn(
+            "⚠ npm/scripts/postinstall.js BINARY_VERSION: 1.7.0 has no tag yet",
+            output,
+        )
+        self.assertIn("✓ All versions in sync", output)
+
+    def test_stale_npm_package_version_fails(self):
+        # npm/package.json left at an older released version than canonical.
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(
+                tmp, canonical="1.6.0", npm_ver="1.4.0", binary_ver="1.6.0"
+            )
+            with self._stubbed(
+                mod, tmp, latest_tag="1.6.0", existing_tags={"v1.4.0", "v1.6.0"}
+            ) as out:
+                rc = mod.run(tmp)
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ npm/package.json: 1.4.0 is stale", out.getvalue())
+
+    def test_npm_js_only_version_ahead_passes(self):
+        # JS-only npm patch: npm ahead of app, no app tag for it — allowed,
+        # and BINARY_VERSION stays on the latest released tag.
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(
+                tmp, canonical="1.6.0", npm_ver="1.6.2", binary_ver="1.6.0"
+            )
+            with self._stubbed(
+                mod, tmp, latest_tag="1.6.0", existing_tags={"v1.6.0"}
+            ) as out:
+                rc = mod.run(tmp)
+        output = out.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn(
+            "✓ npm/package.json: 1.6.2 (JS-only version ahead of app 1.6.0)", output
+        )
+        self.assertIn("✓ All versions in sync", output)
+
+    def test_expect_tag_all_match_passes(self):
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, canonical="1.7.0")
+            with self._stubbed(
+                mod, tmp, latest_tag="1.7.0", existing_tags={"v1.7.0"}
+            ) as out:
+                rc = mod.run(tmp, expect="1.7.0")
+        output = out.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("Strict release mode: every version must equal 1.7.0", output)
+        self.assertIn("✓ All versions in sync", output)
+
+    def test_expect_tag_stale_binary_version_fails(self):
+        # Release gate replay of 1.6.0: tag v1.6.0 pushed, pin still 1.4.0.
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, canonical="1.6.0", binary_ver="1.4.0")
+            with self._stubbed(
+                mod, tmp, latest_tag="1.6.0", existing_tags={"v1.4.0", "v1.6.0"}
+            ) as out:
+                rc = mod.run(tmp, expect="1.6.0")
+        output = out.getvalue()
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "✗ npm/scripts/postinstall.js BINARY_VERSION: 1.4.0 (expected 1.6.0",
+            output,
+        )
+
+    def test_expect_tag_canonical_mismatch_fails(self):
+        # Tag pushed from a commit whose files were never bumped.
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, canonical="1.6.0")
+            with self._stubbed(
+                mod, tmp, latest_tag="1.6.0", existing_tags={"v1.6.0"}
+            ) as out:
+                rc = mod.run(tmp, expect="1.7.0")
+        output = out.getvalue()
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ Info.plist is 1.6.0 but the release expects 1.7.0", output)
+
+    def test_expect_tag_npm_mismatch_fails(self):
+        # In strict mode the JS-only allowance is suspended: npm must equal
+        # the release version exactly.
+        mod = _load("check_version_sync")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, canonical="1.7.0", npm_ver="1.7.1")
+            with self._stubbed(
+                mod, tmp, latest_tag="1.7.0", existing_tags={"v1.7.0"}
+            ) as out:
+                rc = mod.run(tmp, expect="1.7.0")
+        self.assertEqual(rc, 1)
+        self.assertIn("✗ npm/package.json: 1.7.1 (expected 1.7.0)", out.getvalue())
+
+    def test_version_helpers_numeric_order(self):
+        mod = _load("check_version_sync")
+        self.assertEqual(
+            mod.highest_version_tag(["v1.9.0", "v1.10.0", "v1.2.11"]), "v1.10.0"
+        )
+        self.assertEqual(mod.highest_version_tag([]), "")
+        self.assertEqual(mod._version_key("v1.10.2"), (1, 10, 2))
+        self.assertEqual(mod._version_key("1.10.2"), (1, 10, 2))
 
 
 # ── release_preflight ─────────────────────────────────────────────────────────

--- a/scripts/test-release-scripts.py
+++ b/scripts/test-release-scripts.py
@@ -360,7 +360,9 @@ class TestVersionSync(unittest.TestCase):
 
 
 class TestReleasePreflight(unittest.TestCase):
-    def _make_project(self, tmp: Path, version: str = "9.9.9") -> None:
+    def _make_project(
+        self, tmp: Path, version: str = "9.9.9", changelog: bool = True
+    ) -> None:
         _write_plist(tmp / "Sources/MarkView/Info.plist", version, "1")
         workflows = tmp / ".github/workflows"
         workflows.mkdir(parents=True, exist_ok=True)
@@ -376,6 +378,10 @@ class TestReleasePreflight(unittest.TestCase):
         )
         (tmp / "scripts").mkdir(exist_ok=True)
         (tmp / "scripts/check_version_sync.py").write_text("# stub\n")
+        if changelog:
+            (tmp / "CHANGELOG.md").write_text(
+                f"# Changelog\n\n## v{version}\n\n- Release notes stub\n"
+            )
 
     def _fake_run(
         self,
@@ -385,6 +391,11 @@ class TestReleasePreflight(unittest.TestCase):
         swift_ok: bool = True,
         dist_ok: bool = True,
         sync_rc: int = 0,
+        dirty: bool = False,
+        branch: str = "main",
+        local_tag: str = "",
+        remote_tag: str = "",
+        npm_view_out: str = "",
     ):
         def fake_run(cmd, cwd=None):
             prog = Path(str(cmd[0])).name
@@ -401,6 +412,22 @@ class TestReleasePreflight(unittest.TestCase):
                     body = "".join(f"{v}\tvalue\t2026-01-01\n" for v in variables)
                     return 0, body, ""
                 return 1, "", "unexpected gh call"
+            if prog == "git":
+                sub = cmd[1]
+                if sub == "status":
+                    return 0, ("?? untracked.txt\n" if dirty else ""), ""
+                if sub == "rev-parse":
+                    return 0, f"{branch}\n", ""
+                if sub == "tag":
+                    return 0, (f"{local_tag}\n" if local_tag else ""), ""
+                if sub == "ls-remote":
+                    body = f"deadbeef\trefs/tags/{remote_tag}\n" if remote_tag else ""
+                    return 0, body, ""
+                return 1, "", "unexpected git call"
+            if prog == "npm":
+                if npm_view_out:
+                    return 0, f"{npm_view_out}\n", ""
+                return 1, "", "npm ERR! 404"
             if prog == "swift":
                 if swift_ok:
                     return 0, "Total: 300 passed, 0 failed\n", ""
@@ -481,19 +508,97 @@ class TestReleasePreflight(unittest.TestCase):
             output,
         )
 
-    def test_failing_version_sync_is_warning_only(self):
+    def test_failing_version_sync_blocks(self):
+        # Inverts the old warning-only contract: WARN-level sync is what let
+        # 1.6.0 tag with a stale BINARY_VERSION. Sync failure now blocks.
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
             self._make_project(tmp)
             rc, output = self._run_preflight(
                 tmp, self._fake_run(secrets=ALL_SECRETS, sync_rc=1)
             )
+            self.assertFalse((tmp / ".release-preflight-passed-9.9.9").exists())
+        self.assertEqual(rc, 1)
+        self.assertIn("[FAIL] Version sync FAILED", output)
+        self.assertIn("--expect-tag v9.9.9", output)
+
+    def test_version_sync_called_in_strict_mode(self):
+        calls: list[list[str]] = []
+        inner = self._fake_run(secrets=ALL_SECRETS)
+
+        def recording(cmd, cwd=None):
+            calls.append([str(part) for part in cmd])
+            return inner(cmd, cwd)
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, version="9.9.9")
+            rc, _ = self._run_preflight(tmp, recording)
         self.assertEqual(rc, 0)
+        sync_calls = [c for c in calls if any("check_version_sync.py" in p for p in c)]
+        self.assertEqual(len(sync_calls), 1)
+        self.assertIn("--expect-tag", sync_calls[0])
+        self.assertIn("v9.9.9", sync_calls[0])
+
+    def test_dirty_tree_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp)
+            rc, output = self._run_preflight(
+                tmp, self._fake_run(secrets=ALL_SECRETS, dirty=True)
+            )
+        self.assertEqual(rc, 1)
         self.assertIn(
-            "[WARN] Version sync check failed — "
-            "verify version numbers match across files",
+            "[FAIL] Working tree dirty — commit or stash before tagging", output
+        )
+
+    def test_wrong_branch_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp)
+            rc, output = self._run_preflight(
+                tmp, self._fake_run(secrets=ALL_SECRETS, branch="release-hardening")
+            )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "[FAIL] On branch 'release-hardening' — releases are tagged from main only",
             output,
         )
+
+    def test_existing_tag_fails(self):
+        for kwargs in ({"local_tag": "v9.9.9"}, {"remote_tag": "v9.9.9"}):
+            with self.subTest(**kwargs):
+                with tempfile.TemporaryDirectory() as td:
+                    tmp = Path(td)
+                    self._make_project(tmp)
+                    rc, output = self._run_preflight(
+                        tmp, self._fake_run(secrets=ALL_SECRETS, **kwargs)
+                    )
+                self.assertEqual(rc, 1)
+                self.assertIn(
+                    "[FAIL] Tag v9.9.9 already exists — bump the version first",
+                    output,
+                )
+
+    def test_missing_changelog_entry_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp, changelog=False)
+            rc, output = self._run_preflight(tmp, self._fake_run(secrets=ALL_SECRETS))
+        self.assertEqual(rc, 1)
+        self.assertIn("[FAIL] CHANGELOG.md has no '## v9.9.9' entry", output)
+
+    def test_npm_version_collision_fails(self):
+        # mcp-server-markview@9.9.9 already on the registry: npm-publish.yml
+        # would skip the publish and npm users keep the previous binary pin.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._make_project(tmp)
+            rc, output = self._run_preflight(
+                tmp, self._fake_run(secrets=ALL_SECRETS, npm_view_out="9.9.9")
+            )
+        self.assertEqual(rc, 1)
+        self.assertIn("[FAIL] mcp-server-markview@9.9.9 is already published", output)
 
     def test_stale_spm_cache_is_cleared(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Hardens the release pipeline so the 1.6.0 → 1.6.1 incident class (version drift + dual npm publishers) fails loudly at every boundary instead of shipping.

## Root causes (1.6.0)

1. `release.sh` bumped 5 of the 6 version files; `BINARY_VERSION` needed an opt-in `--bump-binary` flag, so the default path left npm pinned to the v1.4.0 binary from April through 1.6.0.
2. `check_version_sync.py` only asserted the pinned tag *exists* — a check that cannot fail for a stale pin. Every CI/local gate stayed green through 3 months of drift.
3. `release_preflight.py` treated version-sync failure as WARN and still wrote the tag-push sentinel.
4. Two npm publishers: release.yml published from the tag commit while the pin fix sat on main. 744c8a7 removed that step, but `release.sh` still carried a live `npm publish` path, and nothing prevented re-adding one.

## Gates added

- **check_version_sync.py**: stale-version detection (BINARY_VERSION must be the *highest* vX.Y.Z tag, numeric sort; npm/package.json may only run ahead for JS-only versions) plus a strict `--expect-tag vX.Y.Z` mode where all six version-carrying files must equal the release exactly.
- **release.yml**: new first step on tag pushes runs the strict check — a mislabeled tag fails in seconds, not after a 60-90 min notarized build.
- **release_preflight.py**: strict sync is now FAIL-level; adds clean-tree, branch==main, tag non-existence (local+remote), CHANGELOG entry, and npm version-collision checks — all before the pre-push sentinel is written.
- **npm_publish_gate.py** (new, run by npm-publish.yml before `npm publish`): coordinated releases require pin == npm version (waits up to 180 s for the trailing tag push); JS-only publishes require pin == latest published release; always requires the `MarkView-<pin>.tar.gz` release asset to exist. npm-publish.yml gains a `workflow_run` retry on Release success, so the coordinated-release ordering resolves automatically (idempotent via the already-published check).
- **check_release_destinations.py** (new, wired into guard.yml): `npm publish` / `mcp-publisher publish` allowed only in npm-publish.yml, NPM_TOKEN allowed nowhere, and the owner must keep its publish step + `id-token: write`. release.sh's duplicate publish/upload path is deleted and `--bump-binary` removed — BINARY_VERSION now always bumps with a release.
- All three new wirings are registered in `rule-gates.json`, so unwiring any gate fails `check-rule-gates.sh` in CI.

## Test plan

- `python3 scripts/test-release-scripts.py`: 51 tests OK (was 24). New cases include both 1.6.0 replays (stale pin in default and strict mode), the tag-arrives-during-wait race, the release.yml re-added-publish replay, comment immunity, and NPM_TOKEN detection.
- `python3 scripts/verify.py`: all stages pass (build, bundle, goldens, script tests, CLI).
- Live failure demos (exit 1 confirmed): pin set to 1.4.0 → STALE; `--expect-tag v1.6.1` vs the tree's real 1.6.0 pin; `npm publish` appended to release.yml. Live `npm_publish_gate.py` run against the real GitHub API classifies the current tree correctly (exit 0).
- `bash scripts/check-rule-gates.sh`: 15 rules OK.

No version bumps; no releases; no behavior change for JS-only npm patches (pin latest release) or mid-release bump commits (warn, not fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
