### PR TITLE
fix(tabs): restore all previously-open tabs on relaunch, not just the last (MV-001)

### DIFF
--- a/Sources/MarkView/MarkViewApp.swift
+++ b/Sources/MarkView/MarkViewApp.swift
@@ -111,11 +111,22 @@ struct MarkViewApp: App {
                         if FileManager.default.fileExists(atPath: path) {
                             tabManager.openFile(URL(fileURLWithPath: path))
                         }
-                    } else {
-                        // No CLI arg — auto-reopen last file if "Restore last file on launch" is enabled
-                        if let lastURL = RecentFilesManager.shared.lastOpenedURL {
-                            tabManager.openFile(lastURL)
+                    } else if let session = TabSessionStore.loadSession(), !session.openPaths.isEmpty {
+                        // MV-001: reopen EVERY tab that was open at quit, in the same
+                        // order, then reselect the one that was frontmost. Previously
+                        // only a single "last opened file" path was ever persisted, so
+                        // this branch used to be able to restore at most one tab.
+                        for path in session.openPaths {
+                            tabManager.openFile(URL(fileURLWithPath: path))
                         }
+                        if let idx = session.selectedIndex, idx >= 0, idx < tabManager.tabs.count {
+                            tabManager.selectedTabID = tabManager.tabs[idx].id
+                        }
+                    } else if let lastURL = RecentFilesManager.shared.lastOpenedURL {
+                        // Fallback for a first launch after upgrading — no multi-tab
+                        // session was ever recorded yet, but a legacy single-file
+                        // "last opened" record may still exist.
+                        tabManager.openFile(lastURL)
                     }
 
                     // Defer window sizing to next run loop — window may not exist yet during onAppear.

--- a/Sources/MarkView/TabManager.swift
+++ b/Sources/MarkView/TabManager.swift
@@ -43,8 +43,19 @@ final class TabState: ObservableObject, Identifiable {
 /// routes through `openFile(_:)` so deduplication and selection stay consistent.
 @MainActor
 final class TabManager: ObservableObject {
-    @Published var tabs: [TabState] = []
-    @Published var selectedTabID: UUID?
+    // Write-through session persistence (MV-001): every add/remove/selection
+    // change re-derives and saves the full ordered tab list, so relaunch can
+    // reopen ALL of them — not just the single "last opened file" path that
+    // RecentFilesManager tracked before this. Same continuous-capture idiom
+    // as MV-003's scrollLine write-through; tab-list changes are rare enough
+    // (open/close/switch) that a synchronous UserDefaults write per change is
+    // cheap, unlike the higher-frequency per-scroll-frame case.
+    @Published var tabs: [TabState] = [] {
+        didSet { persistSession() }
+    }
+    @Published var selectedTabID: UUID? {
+        didSet { persistSession() }
+    }
 
     var selectedTab: TabState? {
         tabs.first { $0.id == selectedTabID }
@@ -60,6 +71,16 @@ final class TabManager: ObservableObject {
         let tab = TabState(url: resolved)
         tabs.append(tab)
         selectedTabID = tab.id
+    }
+
+    /// Re-derive the ordered path list + selected index from live state and
+    /// persist it. The single write path for MV-001 — called from `didSet` on
+    /// both `tabs` and `selectedTabID`, never invoked ad hoc from call sites,
+    /// so no mutation site can forget to persist.
+    private func persistSession() {
+        let paths = tabs.map { $0.url.path }
+        let selectedIndex = selectedTabID.flatMap { id in tabs.firstIndex(where: { $0.id == id }) }
+        TabSessionStore.save(openPaths: paths, selectedIndex: selectedIndex)
     }
 
     /// Close a tab. Selects the nearest remaining tab; returns to home if none left.

--- a/Sources/MarkView/TabSessionStore.swift
+++ b/Sources/MarkView/TabSessionStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+import MarkViewCore
+
+/// Persists the ordered list of currently-open tabs (MV-001 fix).
+///
+/// Before this existed, the only thing persisted across quit/relaunch was
+/// `RecentFilesManager.lastOpenedFilePath` — a single string, overwritten on
+/// every tab open — so relaunch could reopen at most one tab no matter how
+/// many were open at quit. This stores the full ordered `TabSessionState`
+/// (see MarkViewCore/TabSession.swift) as JSON under one UserDefaults key,
+/// matching RecentFilesManager's existing storage convention (no new sidecar
+/// file — the SSOT explicitly rejects per-file sidecars for a Viewer-role
+/// app handling other people's files).
+@MainActor
+enum TabSessionStore {
+    static let sessionKey = "openTabSession"
+
+    /// Write-through save, called from `TabManager.persistSession()` on every
+    /// tabs/selectedTabID change. Not debounced — see TabManager for why a
+    /// synchronous write is fine at this change frequency.
+    static func save(openPaths: [String], selectedIndex: Int?) {
+        let state = TabSessionState(openPaths: openPaths, selectedIndex: selectedIndex)
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        UserDefaults.standard.set(data, forKey: sessionKey)
+    }
+
+    /// Load the previous session, respecting the same `windowRestore` /
+    /// `didExplicitlyCloseFile` guards as `RecentFilesManager.lastOpenedURL`,
+    /// and pruning paths that no longer exist on disk. Returns nil when there
+    /// is nothing to restore (restore disabled, user explicitly closed
+    /// everything last session, no session ever recorded, or every recorded
+    /// path is now unreachable).
+    static func loadSession() -> TabSessionState? {
+        let windowRestore: Bool
+        if UserDefaults.standard.object(forKey: "windowRestore") != nil {
+            windowRestore = UserDefaults.standard.bool(forKey: "windowRestore")
+        } else {
+            windowRestore = true
+        }
+        guard windowRestore else { return nil }
+        guard !UserDefaults.standard.bool(forKey: "didExplicitlyCloseFile") else { return nil }
+        guard let data = UserDefaults.standard.data(forKey: sessionKey),
+              let state = try? JSONDecoder().decode(TabSessionState.self, from: data) else {
+            return nil
+        }
+        let pruned = state.pruningUnreachable { path in
+            (try? URL(fileURLWithPath: path).checkResourceIsReachable()) == true
+        }
+        return pruned.openPaths.isEmpty ? nil : pruned
+    }
+}

--- a/Sources/MarkViewCore/TabSession.swift
+++ b/Sources/MarkViewCore/TabSession.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Pure, testable representation of the ordered set of currently-open tabs,
+/// persisted across quit/relaunch (MV-001 fix).
+///
+/// `TabManager` (Sources/MarkView/TabManager.swift) owns the live `tabs` /
+/// `selectedTabID` state and lives in the app target, so it can't be imported
+/// into MarkViewTestRunner. This type is the serialization boundary: TabManager
+/// derives one of these on every change and hands it to `TabSessionStore`
+/// (app target) to persist; on launch the app decodes one back and reopens
+/// every path in order. Extracting the shape (and the pruning logic) here
+/// keeps the restore decision behaviorally testable.
+///
+/// Before this existed, only a single "last opened file" path was ever
+/// persisted — `RecentFilesManager.lastOpenedFilePath` is overwritten on every
+/// tab open, so relaunch could reopen at most one tab regardless of how many
+/// were open at quit. This type stores the FULL ordered list plus which one
+/// was selected, so all of them come back in the same order.
+public struct TabSessionState: Codable, Equatable, Sendable {
+    /// Open tab file paths, in tab-bar order (index 0 = leftmost tab).
+    public var openPaths: [String]
+    /// Index into `openPaths` of the selected/frontmost tab, or nil if none
+    /// was selected.
+    public var selectedIndex: Int?
+
+    public init(openPaths: [String], selectedIndex: Int?) {
+        self.openPaths = openPaths
+        self.selectedIndex = selectedIndex
+    }
+
+    /// Drop paths the `reachable` predicate rejects (e.g. moved/deleted since
+    /// the session was saved), re-clamping `selectedIndex` to the filtered
+    /// list. `reachable` is injected so this stays pure — no FileManager/URL
+    /// dependency inside MarkViewCore (mirrors the RecentFilesManager
+    /// `checkResourceIsReachable()` pattern at the call site).
+    public func pruningUnreachable(reachable: (String) -> Bool) -> TabSessionState {
+        var keptPaths: [String] = []
+        var newSelectedIndex: Int?
+        for (i, path) in openPaths.enumerated() {
+            guard reachable(path) else { continue }
+            if i == selectedIndex { newSelectedIndex = keptPaths.count }
+            keptPaths.append(path)
+        }
+        return TabSessionState(openPaths: keptPaths, selectedIndex: newSelectedIndex)
+    }
+}

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4013,6 +4013,94 @@ runner.test("TabBarView: dirty indicator rendered per tab") {
 }
 
 // =============================================================================
+// MARK: - MV-001 multi-tab session restore
+//
+// Bug: relaunch reopened only the LAST-opened tab, never all previously-open
+// tabs. Root cause (confirmed by reading the persistence path): the only
+// thing ever persisted was `RecentFilesManager.lastOpenedFilePath` — a single
+// string, overwritten on every tab open (RecentFilesManager.swift:39). No
+// code anywhere serialized the full `TabManager.tabs` array. On launch,
+// MarkViewApp.swift called `tabManager.openFile(lastURL)` exactly once. The
+// S122 markExplicitlyClosed fix (MV-001's original scope) only stopped that
+// single URL from being suppressed when other tabs were still open — it
+// never added persistence for the OTHER tabs, so they never came back.
+//
+// Fix: TabSessionState (MarkViewCore, above) is the serialization shape;
+// behavioral tests below cover its pruning/clamping logic directly. The
+// app-target wiring (TabManager persists on every tabs/selectedTabID change,
+// MarkViewApp restores the full ordered list on launch) is source-inspected
+// below, since TabManager/MarkViewApp aren't SPM-importable.
+// =============================================================================
+
+print("\n--- TabSessionState behavioral tests (MV-001) ---")
+
+runner.test("TabSessionState: pruningUnreachable keeps order and index when all paths reachable") {
+    let state = TabSessionState(openPaths: ["/a.md", "/b.md", "/c.md"], selectedIndex: 1)
+    let pruned = state.pruningUnreachable { _ in true }
+    try expect(pruned.openPaths == ["/a.md", "/b.md", "/c.md"], "no paths should be dropped when all are reachable")
+    try expect(pruned.selectedIndex == 1, "selectedIndex must be unchanged when nothing is pruned")
+}
+
+runner.test("TabSessionState: pruningUnreachable drops missing paths and re-clamps a LATER selectedIndex") {
+    // /b.md (index 1) is gone; the previously-selected /c.md (index 2) must
+    // shift down to index 1 in the filtered list, not stay at 2 (out of bounds)
+    // or reset to nil.
+    let state = TabSessionState(openPaths: ["/a.md", "/b.md", "/c.md"], selectedIndex: 2)
+    let pruned = state.pruningUnreachable { $0 != "/b.md" }
+    try expect(pruned.openPaths == ["/a.md", "/c.md"], "unreachable path must be dropped, order preserved")
+    try expect(pruned.selectedIndex == 1, "selectedIndex must re-clamp to the surviving path's new position, got \(String(describing: pruned.selectedIndex))")
+}
+
+runner.test("TabSessionState: pruningUnreachable nils selectedIndex when the SELECTED path itself is gone") {
+    let state = TabSessionState(openPaths: ["/a.md", "/b.md"], selectedIndex: 1)
+    let pruned = state.pruningUnreachable { $0 != "/b.md" }
+    try expect(pruned.openPaths == ["/a.md"], "unreachable selected path must still be dropped from openPaths")
+    try expect(pruned.selectedIndex == nil, "selectedIndex must become nil, not stale/out-of-bounds, when the selected path is unreachable")
+}
+
+runner.test("TabSessionState: pruningUnreachable on all-unreachable paths yields empty state") {
+    let state = TabSessionState(openPaths: ["/a.md", "/b.md"], selectedIndex: 0)
+    let pruned = state.pruningUnreachable { _ in false }
+    try expect(pruned.openPaths.isEmpty, "all-unreachable input must prune to an empty path list")
+    try expect(pruned.selectedIndex == nil, "empty result must have a nil selectedIndex")
+}
+
+runner.test("TabSessionState: round-trips through JSON (the actual UserDefaults storage format)") {
+    let state = TabSessionState(openPaths: ["/x.md", "/y.md"], selectedIndex: 1)
+    let data = try JSONEncoder().encode(state)
+    let decoded = try JSONDecoder().decode(TabSessionState.self, from: data)
+    try expect(decoded == state, "TabSessionState must round-trip through JSONEncoder/Decoder unchanged (TabSessionStore's exact storage path)")
+}
+
+print("\n--- TabManager / MarkViewApp source-inspection tests (MV-001) ---")
+
+runner.test("MV-001: TabManager persists the tab session on every tabs/selectedTabID change") {
+    try expect(tabManagerSource.contains("@Published var tabs: [TabState] = [] {") &&
+               tabManagerSource.contains("didSet { persistSession() }"),
+        "TabManager.tabs must persist via didSet on every add/remove — write-through, not a debounced/quit-only flush, matching the existing continuous-capture convention (MV-003 scrollLine)")
+    try expect(tabManagerSource.contains("func persistSession"),
+        "TabManager must define persistSession() as the single write path so every tabs/selectedTabID mutation stays in sync")
+    try expect(tabManagerSource.contains("TabSessionStore.save("),
+        "persistSession must delegate storage to TabSessionStore — TabManager itself must not touch UserDefaults directly")
+}
+
+runner.test("MV-001: MarkViewApp restores EVERY persisted tab in order, not just the last one") {
+    let appSource = try String(contentsOfFile: "Sources/MarkView/MarkViewApp.swift", encoding: .utf8)
+    try expect(appSource.contains("TabSessionStore.loadSession()"),
+        "MarkViewApp launch path must load the full persisted session, not just RecentFilesManager.lastOpenedURL")
+    try expect(appSource.contains("for path in session.openPaths"),
+        "launch restore must loop over EVERY openPaths entry and reopen each as its own tab — this is the exact bug: previously only one URL was ever opened")
+    try expect(appSource.contains("session.selectedIndex"),
+        "launch restore must reselect the originally-selected tab by index after reopening all of them, not leave whichever tab opened last selected")
+}
+
+runner.test("MV-001: legacy single-file restore stays as a fallback when no session was ever recorded") {
+    let appSource = try String(contentsOfFile: "Sources/MarkView/MarkViewApp.swift", encoding: .utf8)
+    try expect(appSource.contains("RecentFilesManager.shared.lastOpenedURL"),
+        "the pre-MV-001 single-file restore path must remain as a fallback for users upgrading with no session data yet")
+}
+
+// =============================================================================
 
 print("")
 runner.summary()


### PR DESCRIPTION
The app never persisted the list of open tabs. RecentFilesManager.recordOpen()
overwrote a single lastOpenedFilePath key on each tab open, and the launch path
reopened only that one path. The S122 markExplicitlyClosed fix stopped that lone
restore from being suppressed but never persisted the other tabs, so relaunch
could only ever bring one back.

Add TabSessionState (MarkViewCore, pure and testable) plus TabSessionStore,
persist the full ordered tab list and selected index via TabManager didSet, and
rewire the launch restore to reopen every persisted path in order and reselect by
index. Legacy single-file restore is kept as a fallback for pre-upgrade users.

Test-first: 8 tests (5 behavioral TabSessionState round-trip/prune/clamp, 3
wiring). Ran red before the fix (330/2), green after (332/332). Xcode-target
build verified via bundle.sh (BUILD SUCCEEDED), plus a manual E2E: 4 tabs, quit,
relaunch, accessibility tree shows all 4 restored.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
