### PR TITLE
feat(tabs): ⌘T opens a true untitled tab (MV-007)

### DIFF
--- a/Sources/MarkView/ContentView.swift
+++ b/Sources/MarkView/ContentView.swift
@@ -102,7 +102,7 @@ private struct ActiveTabView: View {
                                 findBar: findBar,
                                 onWebViewCreated: { viewModel.previewWebView = $0 }
                             )
-                            .id(viewModel.currentFilePath ?? "")
+                            .id(tab.id)
                             .frame(minWidth: 200, idealWidth: .infinity, maxWidth: .infinity)
                             .accessibilityElement(children: .contain)
                         }
@@ -118,7 +118,7 @@ private struct ActiveTabView: View {
                             findBar: findBar,
                             onWebViewCreated: { viewModel.previewWebView = $0 }
                         )
-                        .id(viewModel.currentFilePath ?? "")
+                        .id(tab.id)
                     }
                 } else {
                     HomeScreenView { url in
@@ -181,11 +181,20 @@ private struct ActiveTabView: View {
                 if conflict { showExternalChangeAlert = true }
             }
             .onReceive(NotificationCenter.default.publisher(for: .saveDocument)) { _ in
-                do {
-                    try viewModel.save()
-                } catch {
-                    errorPresenter.show("Save failed", detail: error.localizedDescription)
-                    AppLogger.captureError(error, category: "file", message: "Manual save failed")
+                if tab.url == nil {
+                    // Untitled scratch tab (MV-007): no file on disk yet, so ⌘S must
+                    // prompt for a location and promote the tab to a real file. This is
+                    // the ONE site that intercepts save for a nil-url tab — the NSSavePanel
+                    // lives here in the View layer so PreviewViewModel keeps zero AppKit
+                    // panel dependencies (mirrors NSOpenPanel living in MarkViewApp).
+                    saveUntitledTab()
+                } else {
+                    do {
+                        try viewModel.save()
+                    } catch {
+                        errorPresenter.show("Save failed", detail: error.localizedDescription)
+                        AppLogger.captureError(error, category: "file", message: "Manual save failed")
+                    }
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .exportHTML)) { _ in
@@ -259,6 +268,27 @@ private struct ActiveTabView: View {
         } else {
             // Already on home screen — close window.
             NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: nil, from: nil)
+        }
+    }
+
+    /// ⌘S on an untitled tab (MV-007): run an NSSavePanel, then promote the tab to
+    /// a real file via TabManager. Kept in the View layer so PreviewViewModel stays
+    /// free of AppKit panel dependencies (mirrors NSOpenPanel living in MarkViewApp).
+    private func saveUntitledTab() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [
+            .init(filenameExtension: "md")!,
+            .init(filenameExtension: "markdown")!,
+        ]
+        panel.nameFieldStringValue = "Untitled.md"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try tabManager.promoteUntitledTab(tab, to: url)
+            registerFileInWindow(url.path)
+        } catch {
+            errorPresenter.show("Save failed", detail: error.localizedDescription)
+            AppLogger.captureError(error, category: "file", message: "Untitled tab save failed")
         }
     }
 

--- a/Sources/MarkView/MarkViewApp.swift
+++ b/Sources/MarkView/MarkViewApp.swift
@@ -160,7 +160,10 @@ struct MarkViewApp: App {
                 Button(Strings.openFile) { openFile() }
                     .keyboardShortcut("o", modifiers: .command)
 
-                Button("New Tab") { openFile() }
+                // ⌘T opens a true untitled scratch tab (MV-007), no longer an alias
+                // for ⌘O's file picker — that made ⌘T redundant with ⌘O. ⌘O below
+                // stays the file picker, so the two are now genuinely distinct.
+                Button("New Tab") { tabManager.newUntitledTab() }
                     .keyboardShortcut("t", modifiers: .command)
 
                 Menu(Strings.openRecent) {

--- a/Sources/MarkView/PreviewViewModel.swift
+++ b/Sources/MarkView/PreviewViewModel.swift
@@ -53,6 +53,24 @@ final class PreviewViewModel: ObservableObject {
         startAutoSaveTimer()
     }
 
+    /// Start an untitled scratch buffer (MV-007): loaded and editable, but with no
+    /// file on disk. Deliberately skips everything loadFile does that assumes a real
+    /// path — no RecentFilesManager.recordOpen, no watchFile/FileWatcher, no
+    /// startAutoSaveTimer — because there is nothing on disk yet to record, watch,
+    /// or save to. The first successful ⌘S promotes the tab via
+    /// TabManager.promoteUntitledTab → loadFile, which starts all of those exactly
+    /// once. Loads the template + renders an empty document so typing renders live.
+    func startUntitled() {
+        loadTemplate()
+        currentFilePath = nil
+        fileName = "Untitled"
+        editorContent = ""
+        originalContent = ""
+        isDirty = false
+        renderImmediate("")
+        isLoaded = true
+    }
+
     func contentDidChange(_ newText: String) {
         editorContent = newText
         isDirty = newText != originalContent

--- a/Sources/MarkView/TabManager.swift
+++ b/Sources/MarkView/TabManager.swift
@@ -8,7 +8,13 @@ import SwiftUI
 @MainActor
 final class TabState: ObservableObject, Identifiable {
     let id = UUID()
-    let url: URL
+
+    /// The file this tab shows, or nil for an untitled scratch tab (MV-007) with
+    /// no file on disk yet. Transitions from nil to a real value exactly once, on
+    /// the first successful save (TabManager.promoteUntitledTab). @Published so the
+    /// tab bar re-derives displayName the moment an untitled tab is promoted.
+    @Published var url: URL?
+
     let viewModel: PreviewViewModel
 
     /// Last preview scroll position as a 1-based markdown source line (0 = top).
@@ -22,7 +28,14 @@ final class TabState: ObservableObject, Identifiable {
     /// copies it into local @State at creation and writes back on toggle.
     var showEditor: Bool = false
 
+    /// Fixed display name for an untitled (nil-url) tab, chosen once at CREATION in
+    /// TabManager.newUntitledTab() so the number ("Untitled", "Untitled 2", …) does
+    /// not shift when other tabs close (MV-007). Nil for a real-file tab, whose
+    /// displayName derives from `url`.
+    let untitledName: String?
+
     var displayName: String {
+        guard let url else { return untitledName ?? "Untitled" }
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let path = url.path
         if path.hasPrefix(home) {
@@ -33,8 +46,20 @@ final class TabState: ObservableObject, Identifiable {
 
     init(url: URL) {
         self.url = url
+        self.untitledName = nil
         self.viewModel = PreviewViewModel()
         self.viewModel.loadFile(at: url.path)
+    }
+
+    /// Untitled scratch tab (MV-007): no file on disk. Skips loadFile — there is
+    /// no path to load — and instead puts the viewModel in an empty-but-loaded
+    /// state. No recents entry, file watcher, or auto-save timer starts until the
+    /// first save promotes the tab to a real file.
+    init(untitledName: String) {
+        self.url = nil
+        self.untitledName = untitledName
+        self.viewModel = PreviewViewModel()
+        self.viewModel.startUntitled()
     }
 }
 
@@ -64,7 +89,9 @@ final class TabManager: ObservableObject {
     /// Open a file. If already open, switch to it; otherwise create a new tab.
     func openFile(_ url: URL) {
         let resolved = url.resolvingSymlinksInPath()
-        if let existing = tabs.first(where: { $0.url.resolvingSymlinksInPath() == resolved }) {
+        // Optional-chained so untitled (nil-url) tabs are silently skipped rather
+        // than force-unwrapped — dedup is meaningless for a tab with no file (MV-007).
+        if let existing = tabs.first(where: { $0.url?.resolvingSymlinksInPath() == resolved }) {
             selectedTabID = existing.id
             return
         }
@@ -73,13 +100,52 @@ final class TabManager: ObservableObject {
         selectedTabID = tab.id
     }
 
+    /// Open a fresh untitled scratch tab (⌘T, MV-007). It has no file on disk and
+    /// is excluded from session persistence. Deliberately bypasses openFile(_:) —
+    /// dedup is meaningless for a tab with no URL — and forces the editor pane on,
+    /// since a preview with no file loaded is useless. The "Untitled" number is
+    /// fixed here at creation so it does not shift when other tabs close.
+    func newUntitledTab() {
+        let existingUntitled = tabs.filter { $0.url == nil }.count
+        let name = existingUntitled == 0 ? "Untitled" : "Untitled \(existingUntitled + 1)"
+        let tab = TabState(untitledName: name)
+        tab.showEditor = true
+        tabs.append(tab)
+        selectedTabID = tab.id
+    }
+
+    /// Promote an untitled scratch tab into a real file tab after the user picks a
+    /// save location (⌘S on an untitled tab, MV-007). Writes the current editor
+    /// buffer to `url`, then routes through the tab's existing loadFile(at:) — the
+    /// SINGLE untitled→file transition path — so recents, the file watcher, and the
+    /// auto-save timer all start correctly with zero duplicated side effects to keep
+    /// in sync. Setting `url` (which is @Published) refreshes the tab bar title.
+    func promoteUntitledTab(_ tab: TabState, to url: URL) throws {
+        let resolved = url.resolvingSymlinksInPath()
+        try tab.viewModel.editorContent.write(to: resolved, atomically: true, encoding: .utf8)
+        tab.url = resolved
+        tab.viewModel.loadFile(at: resolved.path)
+        // The tab now has a URL, so it belongs in the persisted session. `tabs`/
+        // `selectedTabID` didn't change, so didSet won't fire — persist explicitly.
+        persistSession()
+    }
+
     /// Re-derive the ordered path list + selected index from live state and
     /// persist it. The single write path for MV-001 — called from `didSet` on
     /// both `tabs` and `selectedTabID`, never invoked ad hoc from call sites,
     /// so no mutation site can forget to persist.
     private func persistSession() {
-        let paths = tabs.map { $0.url.path }
-        let selectedIndex = selectedTabID.flatMap { id in tabs.firstIndex(where: { $0.id == id }) }
+        // compactMap (not map): untitled tabs have a nil url and are intentionally
+        // EXCLUDED from persistence — a scratch tab with no file has nothing to
+        // reopen at relaunch (MV-007). map { $0.url.path } would also crash once
+        // url is Optional, so this is a hard regression guard, not a nice-to-have.
+        let paths = tabs.compactMap { $0.url?.path }
+        // The filtered `paths` array has a DIFFERENT index space than `tabs` once
+        // any untitled tab is excluded, so recompute the selected index against the
+        // filtered array (TabSelection is behaviorally tested in MarkViewCore).
+        let hasURL = tabs.map { $0.url != nil }
+        let rawSelectedIndex = selectedTabID.flatMap { id in tabs.firstIndex(where: { $0.id == id }) }
+        let selectedIndex = TabSelection.filteredIndex(hasURL: hasURL, selectedRawIndex: rawSelectedIndex)
         TabSessionStore.save(openPaths: paths, selectedIndex: selectedIndex)
     }
 

--- a/Sources/MarkViewCore/TabSelection.swift
+++ b/Sources/MarkViewCore/TabSelection.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Pure helper for mapping a selected tab's index in the FULL `tabs` array to
+/// its index in the persistence-FILTERED array (untitled/no-URL tabs excluded).
+///
+/// MV-007 makes a tab's URL Optional: an untitled scratch tab has no file on
+/// disk. `TabManager.persistSession()` therefore persists only the tabs that
+/// HAVE a URL (`tabs.compactMap { $0.url?.path }`), so the persisted
+/// `openPaths` array is a filtered subset of `tabs` with a DIFFERENT index
+/// space. The selected index stored alongside it must be recomputed against
+/// that filtered array — not the raw `tabs` index — otherwise, whenever an
+/// untitled tab sits before the selected one, session restore reselects the
+/// wrong tab.
+///
+/// This is the single highest-risk correctness point in MV-007 (it silently
+/// corrupts MV-001's session restore if wrong) and the one piece genuinely
+/// unit-testable in isolation — `TabManager` is app-target and not
+/// SPM-importable — so it is extracted here and covered behaviorally in
+/// MarkViewTestRunner.
+public enum TabSelection {
+    /// Map a raw selected index (into the full tab list) to its index within the
+    /// URL-only filtered list that gets persisted.
+    ///
+    /// - Parameters:
+    ///   - hasURL: one Bool per tab, in tab-bar order; `true` = the tab has a
+    ///     file URL and is included in persistence, `false` = untitled/excluded.
+    ///   - selectedRawIndex: index of the selected tab in the FULL tab list, or
+    ///     nil if nothing is selected.
+    /// - Returns: the selected tab's index within the filtered (URL-only) list,
+    ///   or nil when there is nothing meaningful to persist for the selection —
+    ///   i.e. no selection, an out-of-range index, or the selected tab itself is
+    ///   untitled (has no URL).
+    public static func filteredIndex(hasURL: [Bool], selectedRawIndex: Int?) -> Int? {
+        guard let raw = selectedRawIndex, raw >= 0, raw < hasURL.count else { return nil }
+        // The selected tab itself is untitled — it is not persisted, so there is
+        // no meaningful position for it in the filtered list.
+        guard hasURL[raw] else { return nil }
+        // Position within the filtered list = number of URL-bearing tabs before it.
+        return hasURL[0..<raw].lazy.filter { $0 }.count
+    }
+}

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4101,6 +4101,72 @@ runner.test("MV-001: legacy single-file restore stays as a fallback when no sess
 }
 
 // =============================================================================
+// MARK: - MV-007 untitled tab (Command-T opens a true untitled tab)
+//
+// MV-007 makes TabState.url Optional so ⌘T can open a scratch tab with no file.
+// The single highest-risk correctness point is that persistSession() now filters
+// untitled tabs out of the persisted openPaths (compactMap), so the stored
+// selectedIndex must be recomputed against that FILTERED array — TabSelection
+// below owns that pure logic. Its behavioral coverage (Tier 2) is the required
+// pair for the app-target source-inspection tests further down. Untitled tabs are
+// intentionally EXCLUDED from persistence — a scratch tab is lost on quit.
+// =============================================================================
+
+print("\n--- TabSelection behavioral tests (MV-007, highest-risk: filtered-index recompute) ---")
+
+runner.test("TabSelection: no untitled tabs — index is unchanged") {
+    // All tabs have URLs, so the filtered array == the raw array; index passes through.
+    try expect(TabSelection.filteredIndex(hasURL: [true, true, true], selectedRawIndex: 0) == 0,
+        "with no untitled tabs the raw index 0 must map to filtered 0")
+    try expect(TabSelection.filteredIndex(hasURL: [true, true, true], selectedRawIndex: 2) == 2,
+        "with no untitled tabs the raw index 2 must map to filtered 2")
+}
+
+runner.test("TabSelection: selected real tab sits AFTER an excluded untitled tab — index shifts down") {
+    // [untitled, real, real]; selecting raw index 2 must map to filtered index 1,
+    // because one untitled tab before it is dropped from openPaths. A naive
+    // compactMap-only change (keeping the raw index) would reselect the wrong tab.
+    try expect(TabSelection.filteredIndex(hasURL: [false, true, true], selectedRawIndex: 2) == 1,
+        "raw index 2 with one untitled tab before it must map to filtered index 1, got \(String(describing: TabSelection.filteredIndex(hasURL: [false, true, true], selectedRawIndex: 2)))")
+    // Two untitled tabs before the selected real tab → shift down by two.
+    try expect(TabSelection.filteredIndex(hasURL: [false, false, true], selectedRawIndex: 2) == 0,
+        "raw index 2 with two untitled tabs before it must map to filtered index 0")
+}
+
+runner.test("TabSelection: selected real tab sits BEFORE an excluded untitled tab — index unchanged") {
+    // [real, untitled, real]; selecting raw index 0 stays filtered index 0 —
+    // the untitled tab is after it, so nothing before it is dropped.
+    try expect(TabSelection.filteredIndex(hasURL: [true, false, true], selectedRawIndex: 0) == 0,
+        "raw index 0 with an untitled tab only after it must stay filtered index 0")
+    // [real, untitled, real]; selecting raw index 2 → one untitled before it → filtered 1.
+    try expect(TabSelection.filteredIndex(hasURL: [true, false, true], selectedRawIndex: 2) == 1,
+        "raw index 2 with one untitled tab before it must map to filtered index 1")
+}
+
+runner.test("TabSelection: the selected tab itself is untitled — nil (nothing to reselect)") {
+    try expect(TabSelection.filteredIndex(hasURL: [true, false, true], selectedRawIndex: 1) == nil,
+        "when the SELECTED tab is untitled the filtered index must be nil — it is not in the persisted list")
+    try expect(TabSelection.filteredIndex(hasURL: [false], selectedRawIndex: 0) == nil,
+        "a lone selected untitled tab must map to nil")
+}
+
+runner.test("TabSelection: all tabs untitled — nil regardless of selection") {
+    try expect(TabSelection.filteredIndex(hasURL: [false, false], selectedRawIndex: 0) == nil,
+        "all-untitled with selection at index 0 must be nil")
+    try expect(TabSelection.filteredIndex(hasURL: [false, false], selectedRawIndex: 1) == nil,
+        "all-untitled with selection at index 1 must be nil")
+}
+
+runner.test("TabSelection: nil / out-of-range selection — nil (defensive)") {
+    try expect(TabSelection.filteredIndex(hasURL: [true, true], selectedRawIndex: nil) == nil,
+        "nil selection must map to nil")
+    try expect(TabSelection.filteredIndex(hasURL: [true, true], selectedRawIndex: 5) == nil,
+        "out-of-range selection must map to nil, not crash")
+    try expect(TabSelection.filteredIndex(hasURL: [], selectedRawIndex: 0) == nil,
+        "empty tab list must map to nil")
+}
+
+// =============================================================================
 
 print("")
 runner.summary()

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4235,6 +4235,41 @@ runner.test("MV-007: startUntitled starts NO file-backed side effects (recents/w
         "startUntitled must NOT call loadFile — that path assumes a real file; loadFile is reserved for the promote transition")
 }
 
+runner.test("MV-007: WebPreviewView is keyed by tab.id, not viewModel.currentFilePath") {
+    let cvSource = try String(contentsOfFile: "Sources/MarkView/ContentView.swift", encoding: .utf8)
+    try expect(!cvSource.contains(".id(viewModel.currentFilePath ?? \"\")"),
+        "the old .id(viewModel.currentFilePath ?? \"\") keying must be gone — two open untitled tabs both key to \"\", so SwiftUI would treat them as the same view identity across a tab switch")
+    // Both WebPreviewView occurrences (split-pane + preview-only) must key on tab.id
+    // (the outer ActiveTabView already keys on tab.id, so the total is >= 3).
+    let idCount = cvSource.components(separatedBy: ".id(tab.id)").count - 1
+    try expect(idCount >= 3,
+        "both WebPreviewView occurrences must be keyed by .id(tab.id) so each tab (including untitled ones) gets a distinct SwiftUI identity, got \(idCount) .id(tab.id) sites")
+}
+
+runner.test("MV-007: ⌘S on an untitled tab runs an NSSavePanel and promotes via TabManager (panel stays in the View layer)") {
+    let cvSource = try String(contentsOfFile: "Sources/MarkView/ContentView.swift", encoding: .utf8)
+    try expect(cvSource.contains("if tab.url == nil"),
+        "the .saveDocument handler must branch on tab.url == nil to intercept ⌘S for an untitled tab")
+    try expect(cvSource.contains("NSSavePanel()"),
+        "an untitled ⌘S must present an NSSavePanel so the user can choose a file location")
+    try expect(cvSource.contains("tabManager.promoteUntitledTab(tab, to: url)"),
+        "after the panel returns a URL, the tab must be promoted via TabManager.promoteUntitledTab — the single untitled→file transition")
+    let vmSource = try String(contentsOfFile: "Sources/MarkView/PreviewViewModel.swift", encoding: .utf8)
+    try expect(!vmSource.contains("NSSavePanel"),
+        "PreviewViewModel must NOT reference NSSavePanel — per spec option (b) the panel lives in the View layer, keeping the viewModel free of AppKit panel dependencies")
+}
+
+runner.test("MV-007: the ⌘T \"New Tab\" menu item opens an untitled tab, not the ⌘O file picker") {
+    let appSource = try String(contentsOfFile: "Sources/MarkView/MarkViewApp.swift", encoding: .utf8)
+    try expect(appSource.contains("Button(\"New Tab\") { tabManager.newUntitledTab() }"),
+        "the ⌘T New Tab button must call tabManager.newUntitledTab() — opening a true untitled scratch tab")
+    try expect(!appSource.contains("Button(\"New Tab\") { openFile() }"),
+        "the ⌘T New Tab button must no longer alias openFile() — that made ⌘T redundant with ⌘O")
+    // ⌘O must remain the file picker so the two shortcuts stay genuinely distinct.
+    try expect(appSource.contains("Button(Strings.openFile) { openFile() }"),
+        "⌘O must remain the file-open picker (openFile), unchanged by MV-007")
+}
+
 // =============================================================================
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4166,6 +4166,75 @@ runner.test("TabSelection: nil / out-of-range selection — nil (defensive)") {
         "empty tab list must map to nil")
 }
 
+print("\n--- MV-007 TabManager / PreviewViewModel source-inspection tests ---")
+
+runner.test("MV-007: openFile dedup is optional-safe and TabManager has no .url! force-unwrap") {
+    try expect(tabManagerSource.contains("$0.url?.resolvingSymlinksInPath() == resolved"),
+        "openFile dedup must optional-chain $0.url? so nil-url (untitled) tabs are skipped, never force-unwrapped")
+    try expect(!tabManagerSource.contains(".url!"),
+        "making TabState.url Optional must introduce no .url! force-unwrap anywhere in TabManager — the compiler forces every read site, and each must be optional-chained, not force-unwrapped")
+}
+
+runner.test("MV-007: persistSession compactMaps $0.url?.path (untitled excluded) and recomputes the filtered index") {
+    try expect(tabManagerSource.contains("tabs.compactMap { $0.url?.path }"),
+        "persistSession must use compactMap { $0.url?.path } — untitled tabs are intentionally dropped from the persisted session, and the old map { $0.url.path } would crash once url is Optional (MV-007 regression guard protecting MV-001's persistence path)")
+    try expect(!tabManagerSource.contains("tabs.map { $0.url.path }"),
+        "the pre-MV-007 tabs.map { $0.url.path } must be gone — it force-unwraps a now-Optional url and would crash on an untitled tab")
+    try expect(tabManagerSource.contains("TabSelection.filteredIndex("),
+        "persistSession must recompute the selected index against the FILTERED (URL-only) array via TabSelection.filteredIndex — persisting the raw tabs index would reselect the wrong tab whenever an untitled tab precedes the selection (highest-risk MV-007 point)")
+}
+
+runner.test("MV-007: newUntitledTab appends a nil-url tab, selects it, forces the editor on, and bypasses openFile") {
+    guard let start = tabManagerSource.range(of: "func newUntitledTab") else {
+        try expect(false, "TabManager must define newUntitledTab() for ⌘T"); return
+    }
+    let tail = tabManagerSource[start.lowerBound...]
+    let body = tail.range(of: "\n    func ").map { String(tail[..<$0.lowerBound]) } ?? String(tail)
+    try expect(body.contains("TabState(untitledName:"),
+        "newUntitledTab must create a nil-url TabState via the untitledName initializer (not the file initializer)")
+    try expect(body.contains("tabs.append(tab)") && body.contains("selectedTabID = tab.id"),
+        "newUntitledTab must append the new scratch tab and select it")
+    try expect(body.contains("tab.showEditor = true"),
+        "newUntitledTab must force the editor pane on — a preview with no file loaded is useless")
+    try expect(!body.contains("openFile("),
+        "newUntitledTab must bypass openFile(_:) — dedup is meaningless for a tab with no URL")
+}
+
+runner.test("MV-007: promoteUntitledTab writes the buffer then routes through the single loadFile transition") {
+    guard let start = tabManagerSource.range(of: "func promoteUntitledTab") else {
+        try expect(false, "TabManager must define promoteUntitledTab(_:to:)"); return
+    }
+    let tail = tabManagerSource[start.lowerBound...]
+    let body = tail.range(of: "\n    func ").map { String(tail[..<$0.lowerBound]) } ?? String(tail)
+    try expect(body.contains("editorContent.write("),
+        "promoteUntitledTab must write the current editor buffer to the chosen URL")
+    try expect(body.contains("tab.url = resolved"),
+        "promoteUntitledTab must set the (now-real) url so the tab bar re-derives displayName off it")
+    try expect(body.contains("loadFile(at:"),
+        "promoteUntitledTab must reuse loadFile(at:) as the SINGLE untitled→file transition so recents, file watch, and auto-save all start correctly for free")
+    try expect(body.contains("persistSession()"),
+        "promoteUntitledTab must persist explicitly — tabs/selectedTabID are unchanged so didSet will not fire, but the tab now has a URL and belongs in the restored session")
+}
+
+runner.test("MV-007: startUntitled starts NO file-backed side effects (recents/watcher/auto-save) and skips loadFile") {
+    let vmSource = try String(contentsOfFile: "Sources/MarkView/PreviewViewModel.swift", encoding: .utf8)
+    guard let start = vmSource.range(of: "func startUntitled") else {
+        try expect(false, "PreviewViewModel must define startUntitled()"); return
+    }
+    let tail = vmSource[start.lowerBound...]
+    let body = tail.range(of: "\n    func ").map { String(tail[..<$0.lowerBound]) } ?? String(tail)
+    try expect(body.contains("isLoaded = true"),
+        "startUntitled must mark the buffer loaded so the editor/preview show instead of the home screen")
+    try expect(!body.contains("recordOpen"),
+        "startUntitled must NOT record a recents entry — nothing exists on disk yet")
+    try expect(!body.contains("watchFile") && !body.contains("FileWatcher"),
+        "startUntitled must NOT start a FileWatcher — there is no file on disk to watch")
+    try expect(!body.contains("startAutoSaveTimer"),
+        "startUntitled must NOT start the auto-save timer — there is nothing on disk to save to; the first ⌘S promote starts it via loadFile")
+    try expect(!body.contains("loadFile"),
+        "startUntitled must NOT call loadFile — that path assumes a real file; loadFile is reserved for the promote transition")
+}
+
 // =============================================================================
 
 print("")


### PR DESCRIPTION
## What

MV-007: `⌘T` opens a true untitled tab (scratch buffer with editor pane, no file on disk), promotable to a real file via `⌘S`→NSSavePanel. Resolves the "⌘T is redundant with ⌘O" problem — ⌘O stays the file picker, ⌘T now creates a new buffer.

Implements the spec at `docs/personal/mv-007-untitled-tab-spec-2026-07-04.md`.

> Supersedes #41, which was accidentally opened against the (now-merged) `mv-001-restore-all-tabs` branch. This PR is the same 3 commits rebased cleanly onto `main`.

## Changes
- **`TabSelection.swift` (new, MarkViewCore)** — pure `filteredIndex(hasURL:selectedRawIndex:)` helper; the highest-risk correctness point (recomputing the restored selection against the untitled-filtered `openPaths`), unit-tested in isolation.
- `TabState.url` → `URL?`; `newUntitledTab()` / `promoteUntitledTab(_:to:)`; optional-chained dedup; `persistSession` `map` → `compactMap` (untitled tabs intentionally excluded from persistence).
- `PreviewViewModel.startUntitled()`; ContentView `⌘S` NSSavePanel branch (panel stays in the View layer); `WebPreviewView` `.id(tab.id)` keying.
- `MarkViewApp` `⌘T` rebind to `newUntitledTab()`.

## Interaction with MV-001 (already on main)
Untitled tabs are excluded from session-restore (`compactMap`) — an unsaved scratch tab is lost on quit (same as any unsaved buffer today; MV-012's dirty-quit prompt is the correct fix for "warn before losing"). The filtered-index recompute protects MV-001's restore from mis-selecting when an untitled tab sits below the selected tab.

Two spec assertions verified TRUE against source: `WebPreviewView` external-reload does not depend on the old `.id()` key (Coordinator uses `fileIdentifier`); Optional `url` introduces no `.url!` force-unwrap.

## Test plan
- `swift run MarkViewTestRunner`: **346 passed, 0 failed** (14 new: 6 `TabSelection` behavioral + 8 source-inspection incl. the `compactMap` regression guard).
- `make playwright`: 170 passed, 2 skipped (the `.id(tab.id)` rendering-identity change is green).
- App bundle builds + launches clean.
- **Needs manual verification** (interactive AX/GUI, not headless): ⌘T×2 independent tabs, ⌘S→NSSavePanel promote, quit/relaunch restores only the real tab, Finder-open funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
