### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.7.0
+
+- Restore all previously-open tabs on relaunch, not just the last one (MV-001, #39): reopening MarkView now brings back every tab from your last session, each with its own file watching and preview state.
+- Cmd+T opens a true untitled tab (MV-007, #42): a fresh empty tab for scratch notes, no file on disk required.
+- Lint fix: escaped pipes (`\|`) inside Markdown tables are no longer miscounted as cell delimiters (#37).
+- Release and CI hardening: version drift and publish-destination drift across GitHub, npm, and the MCP registry are now structurally prevented (#38); dSYMs upload to Sentry after notarization so crash reports are symbolicated (#40).
+
 ## v1.6.1
 
 - Fix npm package: `mcp-server-markview@1.6.0` shipped with its postinstall pinned to the v1.4.0 app binary; 1.6.1 pins the current binary so npm installs get the tab-cycling and scroll-restore features. No app code changes.

--- a/Sources/MarkView/Info.plist
+++ b/Sources/MarkView/Info.plist
@@ -42,9 +42,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>303</string>
+	<string>323</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/MarkViewMCPServer/main.swift
+++ b/Sources/MarkViewMCPServer/main.swift
@@ -7,7 +7,7 @@ struct MarkViewMCPServer {
     static func main() async throws {
         let server = Server(
             name: "markview",
-            version: "1.6.1",
+            version: "1.7.0",
             capabilities: .init(
                 resources: .init(subscribe: false, listChanged: false),
                 tools: .init(listChanged: false)

--- a/Sources/MarkViewQuickLook/Info.plist
+++ b/Sources/MarkViewQuickLook/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<string>1.7.0</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>303</string>
+	<string>323</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSExtension</key>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-markview",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "MCP server for MarkView — preview Markdown files in a native macOS viewer",
   "license": "MIT",
   "author": "Paul Kang <contact@paulkang.dev>",

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -25,7 +25,7 @@ const GITHUB_REPO = "markview";
 // BINARY_VERSION pins the macOS app release to download.
 // This is intentionally decoupled from the npm package version —
 // npm patches (JS-only changes) don't require a new macOS binary release.
-const BINARY_VERSION = "1.6.0";
+const BINARY_VERSION = "1.7.0";
 const ARCHIVE_NAME = `MarkView-${BINARY_VERSION}.tar.gz`;
 const DOWNLOAD_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/v${BINARY_VERSION}/${ARCHIVE_NAME}`;
 

--- a/npm/server.json
+++ b/npm/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/paulhkang94/markview",
     "source": "github"
   },
-  "version": "1.6.1",
+  "version": "1.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "mcp-server-markview",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Cuts a full **v1.7.0** release standardized across GitHub + npm + Homebrew, shipping the app features that were stranded after the npm-only 1.6.1 patch.

## Why 1.7.0 (not 1.6.1/1.6.2)
`mcp-server-markview@1.6.1` was an npm-packaging-only patch (postinstall pinned to the v1.6.0 app binary) — it's immutable and already published, and it shipped no app code. MV-001 + MV-007 have been merged to `main` since v1.6.0 but never released to users. 1.7.0 is a minor bump (new feature: MV-007) that ships them across all three channels.

## What ships (commits since v1.6.0)
- **MV-001 (#39)** restore all previously-open tabs on relaunch, not just the last
- **MV-007 (#42)** ⌘T opens a true untitled tab
- **#37** lint: escaped pipes (`\|`) no longer miscounted as table delimiters
- **#38** release/CI hardening (structural drift prevention) + **#40** dSYM upload to Sentry

## Version bump (6 files, build 323)
Info.plist + QuickLook Info.plist (short + build), MCP `main.swift`, `npm/package.json`, `npm/server.json`, and `postinstall.js` `BINARY_VERSION` → `1.7.0` (pins the npm wrapper to the v1.7.0 app binary the tag will publish). `check_version_sync.py`: all in sync.

## After merge (the standardized pipeline)
Tag `v1.7.0` on the merged commit → `release.yml` (build/sign/notarize + GH release) → `npm-publish.yml` (`workflow_run` after Release, OIDC) publishes npm + MCP registry → `tap-update.yml` (`release: published`) updates the Homebrew cask. All three land at 1.7.0 from one tag.

Preflight (`release_preflight.py`) passes except the working-tree-clean check (this commit resolves it); local `MarkViewTestRunner` + distribution-path test passed.