### PR TITLE
Add missing Python hook-port scripts for global Claude Code wiring

### DIFF
--- a/scripts/claude_format.py
+++ b/scripts/claude_format.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""PostToolUse auto-formatter — universal, language-dispatched.
+
+Reads the hook event JSON on stdin, extracts the edited file's path, and runs the
+right formatter for its extension. Consolidates the former scripts/claude-format.sh
+dispatcher plus the 12 scripts/formatters/{lang}.sh wrappers into one file (M7-5,
+approach A): every repo installs this same script instead of a per-language copy,
+so a mixed-language repo now formats every language it touches.
+
+Each language preserves the exact tool chain and fallback order of its bash
+original. Always exits 0 — a PostToolUse formatter must never fail the edit — and
+formats only when the tool is actually installed. jq is replaced by the json
+stdlib.
+
+    echo "$HOOK_JSON" | ./scripts/claude_format.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(cmd: list[str]) -> None:
+    """Run a formatter, swallowing all output and errors (best-effort, in-place)."""
+    try:
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    except OSError:
+        pass
+
+
+def _fmt_python(fp: str) -> None:
+    if shutil.which("ruff"):
+        _run(["ruff", "format", "--quiet", fp])
+        _run(["ruff", "check", "--fix", "--quiet", fp])
+    elif shutil.which("black"):
+        _run(["black", "--quiet", fp])
+        _run(["isort", "--quiet", fp])
+
+
+def _fmt_swift(fp: str) -> None:
+    pods = REPO_ROOT / "Pods" / "SwiftFormat" / "CommandLineTool" / "swiftformat"
+    if os.access(pods, os.X_OK):
+        _run([str(pods), fp])
+    elif shutil.which("swiftformat"):
+        _run(["swiftformat", fp])
+
+
+def _fmt_typescript(fp: str) -> None:
+    npx = shutil.which("npx")
+    if (REPO_ROOT / "biome.json").is_file() or (REPO_ROOT / "biome.jsonc").is_file():
+        if npx:
+            _run(["npx", "@biomejs/biome", "format", "--write", fp])
+    elif (REPO_ROOT / "dprint.json").is_file():
+        if npx:
+            _run(["npx", "dprint", "fmt", fp])
+    elif npx:
+        _run(["npx", "prettier", "--write", fp])
+
+
+def _fmt_go(fp: str) -> None:
+    gopath = ""
+    try:
+        gopath = subprocess.run(
+            ["go", "env", "GOPATH"], capture_output=True, text=True, check=False
+        ).stdout.strip()
+    except OSError:
+        gopath = ""
+    candidates = [
+        f"{gopath}/bin" if gopath else "",
+        str(Path.home() / "go" / "bin"),
+        "/usr/local/go/bin",
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+    ]
+    for d in candidates:
+        if not d:
+            continue
+        goimports = Path(d) / "goimports"
+        if os.access(goimports, os.X_OK):
+            _run([str(goimports), "-w", fp])
+            return
+    _run(["gofmt", "-w", fp])
+
+
+def _fmt_rust(fp: str) -> None:
+    if shutil.which("rustfmt"):
+        _run(["rustfmt", "--edition", "2021", fp])
+
+
+def _fmt_ruby(fp: str) -> None:
+    if shutil.which("rubocop"):
+        _run(["rubocop", "--autocorrect", "--no-color", fp])
+    elif shutil.which("rufo"):
+        _run(["rufo", fp])
+
+
+def _fmt_java(fp: str) -> None:
+    if shutil.which("google-java-format"):
+        _run(["google-java-format", "--replace", fp])
+    elif shutil.which("npx") and (REPO_ROOT / "node_modules" / ".bin" / "prettier").is_file():
+        _run(["npx", "prettier", "--write", fp])
+
+
+def _fmt_kotlin(fp: str) -> None:
+    if shutil.which("ktlint"):
+        _run(["ktlint", "--format", fp])
+    else:
+        print(
+            "[WARN] ktlint not in PATH — formatting skipped. Install: brew install ktlint",
+            file=sys.stderr,
+        )
+
+
+def _fmt_php(fp: str) -> None:
+    if shutil.which("php-cs-fixer"):
+        _run(["php-cs-fixer", "fix", "--quiet", fp])
+    elif shutil.which("phpcbf"):
+        _run(["phpcbf", "--quiet", fp])
+
+
+def _fmt_csharp(fp: str) -> None:
+    if shutil.which("dotnet"):
+        _run(["dotnet", "format", str(REPO_ROOT), "--include", fp, "--no-restore"])
+    elif shutil.which("dotnet-csharpier"):
+        _run(["dotnet-csharpier", fp])
+
+
+def _fmt_scala(fp: str) -> None:
+    if shutil.which("scalafmt"):
+        _run(["scalafmt", "--quiet", fp])
+    elif shutil.which("npx"):
+        _run(["npx", "scalafmt", "--quiet", fp])
+
+
+def _fmt_c(fp: str) -> None:
+    if shutil.which("clang-format"):
+        _run(["clang-format", "-i", fp])
+
+
+# Extension → formatter. Mirrors the per-language .sh dispatch in claude-format.sh.
+_DISPATCH = {
+    ".py": _fmt_python,
+    ".swift": _fmt_swift,
+    ".ts": _fmt_typescript,
+    ".tsx": _fmt_typescript,
+    ".js": _fmt_typescript,
+    ".jsx": _fmt_typescript,
+    ".mjs": _fmt_typescript,
+    ".cjs": _fmt_typescript,
+    ".json": _fmt_typescript,
+    ".go": _fmt_go,
+    ".rs": _fmt_rust,
+    ".rb": _fmt_ruby,
+    ".java": _fmt_java,
+    ".kt": _fmt_kotlin,
+    ".kts": _fmt_kotlin,
+    ".php": _fmt_php,
+    ".cs": _fmt_csharp,
+    ".scala": _fmt_scala,
+    ".sc": _fmt_scala,
+    ".c": _fmt_c,
+    ".cpp": _fmt_c,
+    ".cc": _fmt_c,
+    ".cxx": _fmt_c,
+    ".h": _fmt_c,
+    ".hpp": _fmt_c,
+    ".hxx": _fmt_c,
+}
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    tool_input = payload.get("tool_input")
+    file_path = tool_input.get("file_path") if isinstance(tool_input, dict) else None
+    if not file_path:
+        return 0
+
+    handler = _DISPATCH.get(Path(file_path).suffix.lower())
+    if handler is not None:
+        handler(file_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude_log_failure.py
+++ b/scripts/claude_log_failure.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""PostToolUseFailure hook: log tool failures to metrics JSONL.
+
+Reads the hook event payload as JSON on stdin and does three things, in order:
+
+1. Appends a single v3 ``tool_failure`` JSONL line to
+   ``<repo>/.claude/memory/metrics.jsonl``.
+2. Pattern detection: if this error's 80-char signature recurs >= 2 times in the
+   last 10 metrics events, emits a single ``{"additionalContext": ...}`` JSON
+   object on stdout. Claude Code parses hook stdout as JSON — a malformed line
+   silently drops the hook (the S86 incident class), so the object is built with
+   json.dumps, never string interpolation.
+3. CL fingerprint auto-extraction: hands (tool, error, command) to
+   ``cl_db.py auto-extract`` (skips interrupts).
+
+Port of scripts/claude-log-failure.sh (M7-4b): the bash version required ``jq``
+and sourced ``cl-version.sh``. This reads the version constant from the sibling
+``cl-version.sh`` at runtime and uses the json stdlib, so there is no external
+dependency. Always exits 0 — a logging hook must never break the tool it
+observes; malformed stdin or an unwritable metrics file degrades to a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_JSONL_VERSION = 3
+
+
+def _jsonl_version() -> int:
+    """CL_JSONL_VERSION from the sibling cl-version.sh; any failure → 3.
+
+    Mirrors bash: `source "$(dirname "$0")/cl-version.sh" || CL_JSONL_VERSION=3`.
+    """
+    version_file = Path(__file__).resolve().parent / "cl-version.sh"
+    try:
+        text = version_file.read_text(encoding="utf-8")
+    except OSError:
+        return DEFAULT_JSONL_VERSION
+    match = re.search(r"^CL_JSONL_VERSION=(\d+)\s*$", text, re.MULTILINE)
+    return int(match.group(1)) if match else DEFAULT_JSONL_VERSION
+
+
+def _jq_alt(*candidates: object, default: str) -> object:
+    """jq `a // b // default` — first value that is neither null nor false.
+
+    Note: jq's `//` does NOT treat "" as empty, so an empty string short-circuits
+    the chain (the caller applies the separate `if . == ""` → default step).
+    """
+    for value in candidates:
+        if value is not None and value is not False:
+            return value
+    return default
+
+
+def _str_or_unknown(value: object) -> str:
+    """jq `(.field // "unknown") | if . == "" then "unknown"` — null/empty → unknown."""
+    if value is None or value == "":
+        return "unknown"
+    return str(value)
+
+
+def _session_id(payload: dict, repo_root: Path) -> str:
+    """Native session_id from stdin, falling back to the .session_id file."""
+    sid = payload.get("session_id") or ""
+    if not sid:
+        sid_file = repo_root / ".claude" / "memory" / ".session_id"
+        try:
+            sid = sid_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            sid = ""
+    return sid
+
+
+def _session_metadata(repo_root: Path) -> dict[str, str]:
+    """Opt-in (REPL_SESSION_TAGGING=1) user/work_type/feature_id tags."""
+    if os.environ.get("REPL_SESSION_TAGGING", "0") != "1":
+        return {}
+    meta_file = repo_root / ".claude" / "memory" / ".session_metadata.json"
+    try:
+        meta = json.loads(meta_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(meta, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key in ("user", "work_type", "feature_id"):
+        val = meta.get(key) or ""
+        if val:
+            out[key] = str(val)
+    return out
+
+
+def _build_record(payload: dict, repo_root: Path, repo_name: str) -> dict:
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+
+    # file: file_path first, then command (jq `//`), empty → unknown, cap 200.
+    file_val = _jq_alt(tool_input.get("file_path"), tool_input.get("command"), default="unknown")
+    if file_val == "":
+        file_val = "unknown"
+    file_val = str(file_val)[:200]
+
+    record: dict[str, object] = {
+        "v": _jsonl_version(),
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "repo": repo_name,
+        "event": "tool_failure",
+        "tool": _str_or_unknown(payload.get("tool_name")),
+        "file": file_val,
+        "error": _str_or_unknown(payload.get("error"))[:500],
+        "is_interrupt": payload.get("is_interrupt") or False,
+    }
+
+    sid = _session_id(payload, repo_root)
+    if sid:
+        record["session"] = sid
+    record.update(_session_metadata(repo_root))
+    return record
+
+
+def _emit_pattern_context(payload: dict, metrics_file: Path) -> None:
+    """Emit additionalContext if this error's signature recurs in recent events."""
+    if os.environ.get("REPL_PATTERN_DETECTION", "1") == "0":
+        return
+    sig = str(_jq_alt(payload.get("error"), default=""))[:80]
+    if not sig or sig == "null":
+        return
+    try:
+        lines = metrics_file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    count = 0
+    for line in lines[-10:]:
+        try:
+            rec = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if rec.get("event") == "tool_failure" and str(rec.get("error") or "")[:80] == sig:
+            count += 1
+    if count >= 2:
+        msg = (
+            f"This error has occurred {count} times recently. Check "
+            ".claude/memory/failure-patterns.md for known fixes, or run "
+            "python3 scripts/claude_pattern_detector.py --analyze . for full analysis."
+        )
+        # json.dumps guarantees a valid object — Claude Code parses this as JSON.
+        print(json.dumps({"additionalContext": msg}))
+
+
+def _auto_extract(payload: dict, repo_root: Path) -> None:
+    """Feed (tool, error, command) to cl_db.py auto-extract (skips interrupts)."""
+    if os.environ.get("REPL_FINGERPRINTING", "1") == "0":
+        return
+    db_path = repo_root / ".claude" / "memory" / "learnings.db"
+    cl_db_py = repo_root / "scripts" / "cl_db.py"
+    if not cl_db_py.is_file():
+        cl_db_py = Path(__file__).resolve().parent / "cl_db.py"
+    if not db_path.is_file() or not cl_db_py.is_file():
+        return
+    if payload.get("is_interrupt") is True:
+        return
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    fp_tool = str(_jq_alt(payload.get("tool_name"), default=""))
+    fp_error = str(_jq_alt(payload.get("error"), default=""))[:200]
+    fp_cmd = str(_jq_alt(tool_input.get("command"), tool_input.get("file_path"), default=""))[:200]
+
+    if not fp_error or fp_error == "null":
+        return
+
+    try:
+        subprocess.run(
+            ["python3", str(cl_db_py), "auto-extract", fp_tool, fp_error, fp_cmd],
+            env={**os.environ, "CL_DB_PATH": str(db_path)},
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        return
+
+
+def main() -> int:
+    # Opt-out: set REPL_METRICS=0 or REPL_METRICS_TOOL_FAILURES=0 to disable.
+    if (
+        os.environ.get("REPL_METRICS", "1") == "0"
+        or os.environ.get("REPL_METRICS_TOOL_FAILURES", "1") == "0"
+    ):
+        return 0
+
+    repo_root = Path(__file__).resolve().parent.parent
+    metrics_file = repo_root / ".claude" / "memory" / "metrics.jsonl"
+    repo_name = repo_root.name
+
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    record = _build_record(payload, repo_root, repo_name)
+
+    try:
+        metrics_file.parent.mkdir(parents=True, exist_ok=True)
+        with metrics_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+    except OSError:
+        return 0
+
+    _emit_pattern_context(payload, metrics_file)
+    _auto_extract(payload, repo_root)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude_log_subagent.py
+++ b/scripts/claude_log_subagent.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""SubagentStop hook: log subagent completions to metrics JSONL.
+
+Reads the hook event payload as JSON on stdin and appends a single JSONL line
+to ``<repo>/.claude/memory/metrics.jsonl``.
+
+v4 schema: universal — auto-detects repo name, ``mkdir -p``, ``is_interrupt``,
+``duration_ms``, ``exit_code``. Port of scripts/claude-log-subagent.sh (M7-4);
+the bash version required ``jq`` and sourced ``cl-version.sh``. This reads the
+version constant from the sibling ``cl-version.sh`` at runtime (same contract as
+cl_session_summary.py / claude_build_benchmark.py) and uses the json stdlib, so
+there is no external dependency.
+
+Always exits 0: a logging hook must never break the tool it observes. Malformed
+stdin, an unwritable metrics file, or any other error degrades to a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_SUBAGENT_JSONL_VERSION = 4
+
+
+def _subagent_jsonl_version() -> int:
+    """CL_SUBAGENT_JSONL_VERSION from the sibling cl-version.sh; any failure → 4.
+
+    Mirrors bash: `source "$(dirname "$0")/cl-version.sh" || CL_SUBAGENT_JSONL_VERSION=4`.
+    """
+    version_file = Path(__file__).resolve().parent / "cl-version.sh"
+    try:
+        text = version_file.read_text(encoding="utf-8")
+    except OSError:
+        return DEFAULT_SUBAGENT_JSONL_VERSION
+    match = re.search(r"^CL_SUBAGENT_JSONL_VERSION=(\d+)\s*$", text, re.MULTILINE)
+    return int(match.group(1)) if match else DEFAULT_SUBAGENT_JSONL_VERSION
+
+
+def _str_or_unknown(value: object) -> str:
+    """jq `(.field // "unknown") | if . == "" then "unknown"` — null/empty → unknown."""
+    if value is None or value == "":
+        return "unknown"
+    return str(value)
+
+
+def _session_id(payload: dict, repo_root: Path) -> str:
+    """Native session_id from stdin, falling back to the .session_id file."""
+    sid = payload.get("session_id") or ""
+    if not sid:
+        sid_file = repo_root / ".claude" / "memory" / ".session_id"
+        try:
+            sid = sid_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            sid = ""
+    return sid
+
+
+def _session_metadata(repo_root: Path) -> dict[str, str]:
+    """Opt-in (REPL_SESSION_TAGGING=1) user/work_type/feature_id tags."""
+    if os.environ.get("REPL_SESSION_TAGGING", "0") != "1":
+        return {}
+    meta_file = repo_root / ".claude" / "memory" / ".session_metadata.json"
+    try:
+        meta = json.loads(meta_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(meta, dict):
+        return {}
+    out: dict[str, str] = {}
+    for src, dst in (
+        ("user", "user"),
+        ("work_type", "work_type"),
+        ("feature_id", "feature_id"),
+    ):
+        val = meta.get(src) or ""
+        if val:
+            out[dst] = str(val)
+    return out
+
+
+def main() -> int:
+    # Opt-out: set REPL_METRICS=0 or REPL_METRICS_SUBAGENTS=0 to disable.
+    if (
+        os.environ.get("REPL_METRICS", "1") == "0"
+        or os.environ.get("REPL_METRICS_SUBAGENTS", "1") == "0"
+    ):
+        return 0
+
+    repo_root = Path(__file__).resolve().parent.parent
+    metrics_file = repo_root / ".claude" / "memory" / "metrics.jsonl"
+    repo_name = repo_root.name
+
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    record: dict[str, object] = {
+        "v": _subagent_jsonl_version(),
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "repo": repo_name,
+        "event": "subagent_stop",
+        "agent_type": _str_or_unknown(payload.get("agent_type")),
+        "agent_id": _str_or_unknown(payload.get("agent_id")),
+        "is_interrupt": payload.get("is_interrupt") or False,
+        "duration_ms": payload.get("duration_ms") or 0,
+        "exit_code": payload.get("exit_code") or 0,
+    }
+
+    sid = _session_id(payload, repo_root)
+    if sid:
+        record["session"] = sid
+    record.update(_session_metadata(repo_root))
+
+    try:
+        metrics_file.parent.mkdir(parents=True, exist_ok=True)
+        with metrics_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+    except OSError:
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude_post_session_analysis.py
+++ b/scripts/claude_post_session_analysis.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Stop hook: run post-session pattern analysis.
+
+Fire-and-forget — the session is ending, so there is no output to surface.
+Runs claude_pattern_detector.py --draft-patterns and, when it finds new
+patterns, stages them to .claude/memory/draft-patterns.md for later review.
+
+Port of scripts/claude-post-session-analysis.sh (M7-4c): the bash version
+required jq to read the Stop-hook stdin; this uses the json stdlib. Always
+exits 0 — a Stop hook must never fail the session teardown.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Sessions shorter than this many tool events are not worth analyzing.
+MIN_EVENTS = 10
+DRAFT_THRESHOLD = 3
+# Substrings that mean the detector found nothing worth staging.
+_NO_NEW = ("No new failure patterns", "already documented")
+
+
+def _drain_stdin() -> str:
+    """Read the Stop-hook JSON payload, but never block on an interactive tty."""
+    if sys.stdin.isatty():
+        return ""
+    try:
+        return sys.stdin.read()
+    except OSError:
+        return ""
+
+
+def main() -> int:
+    # Opt-out: REPL_METRICS=0 or REPL_PATTERN_DETECTION=0 disables analysis.
+    if (
+        os.environ.get("REPL_METRICS", "1") == "0"
+        or os.environ.get("REPL_PATTERN_DETECTION", "1") == "0"
+    ):
+        return 0
+
+    repo_root = Path(__file__).resolve().parent.parent
+    metrics_file = repo_root / ".claude" / "memory" / "metrics.jsonl"
+    draft_file = repo_root / ".claude" / "memory" / "draft-patterns.md"
+    detector = repo_root / "scripts" / "claude_pattern_detector.py"
+
+    # Drain stdin (transcript_path is available here but unused, matching the
+    # bash original) so the hook pipe closes cleanly.
+    raw = _drain_stdin()
+    if raw:
+        try:
+            json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # Skip when there is nothing to analyze or the detector is absent.
+    try:
+        lines = metrics_file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return 0
+    if not lines or not detector.is_file():
+        return 0
+
+    # Session-length threshold: skip short sessions.
+    if len(lines) < MIN_EVENTS:
+        return 0
+
+    try:
+        result = subprocess.run(
+            [
+                "python3",
+                str(detector),
+                "--draft-patterns",
+                "--quiet",
+                "--threshold",
+                str(DRAFT_THRESHOLD),
+                str(repo_root),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return 0
+    if result.returncode != 0:
+        return 0
+
+    draft_output = result.stdout.strip()
+    if not draft_output or any(marker in draft_output for marker in _NO_NEW):
+        return 0
+
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    try:
+        draft_file.parent.mkdir(parents=True, exist_ok=True)
+        draft_file.write_text(
+            f"# Draft Patterns (auto-generated {stamp})\n\n"
+            f"{draft_output}\n\n"
+            "_To disable post-session pattern analysis: export REPL_PATTERN_DETECTION=0_\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- markview's local (git-ignored) `.claude/settings.json` wires several project-level hooks to bash scripts that were removed during the org-wide bash→Python hook migration (`claude-format.sh`, `stop-gate.sh`, `claude-post-session-analysis.sh`, `session-end-cost.sh`, `waiting-ping.sh`, `cancel-waiting.sh`, `context-refresh.sh`) — each guarded by a fail-open `[[ -x ./foo.sh ]] && ./foo.sh || exit 0` wrapper, so they've been permanent silent no-ops.
- The machine-global Claude Code settings already deliver `PostToolUseFailure`, `SubagentStop`, and part of `Stop` for every repo via repo-relative `./scripts/...` commands — but those commands require each repo to carry its own copy of the target script. markview was missing `scripts/claude_format.py`, `scripts/claude_log_failure.py`, `scripts/claude_log_subagent.py`, and `scripts/claude_post_session_analysis.py`, so those hooks silently no-op here specifically.
- This PR adds the four missing scripts (byte-identical copies from `claude-repl-template/scripts/`), which is the only piece of the fix that's actually part of markview's git history — `.claude/` and `hooks/` are deliberately git-ignored in this repo ("Development tooling (local only — not for distribution)"), so the `.claude/settings.json` rewiring itself is a local-only fix, verified against `claude-repl-template/scripts/detect_drift.py` (11 → 2 drift issues; the 2 remaining are pre-existing and unrelated: verify-script naming convention, metrics.jsonl gitignore).

## Test plan
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` parses
- [x] Every `command` path referenced in the local settings.json resolves to an existing file
- [x] `grep -n "/Users/pkang" .claude/settings.json` is empty (no personal paths)
- [x] `detect_drift.py --no-machine` confirms all "missing from the repo (fail-open wrapper)" and hook double-fire drift lines are gone
- [x] Pre-commit hooks passed (version sync, rule gates, MCP docs, no private files staged)