### PR TITLE
chore(gitignore): keep Claude harness Python ports local-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ CLAUDE.md
 hooks/
 scripts/cl-*.sh
 scripts/claude-*.sh
+scripts/claude_*.py
 scripts/check-path-safety.sh
 scripts/test-launchd-env.sh
 .last-verify-at


### PR DESCRIPTION
markview's local-only tooling block already excludes scripts/claude-*.sh,
but the harness migration renamed those ports to scripts/claude_*.py, which
slipped past the ignore net. Extend the pattern so the Python telemetry and
format scripts stay local and never ship in the public repo.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
