### PR TITLE
fix(hang): cache JS bundles in a process-wide static, not per Coordinator (item-713)

### DIFF
--- a/Sources/MarkView/WebPreviewView.swift
+++ b/Sources/MarkView/WebPreviewView.swift
@@ -105,62 +105,42 @@ struct WebPreviewView: NSViewRepresentable {
         private var lastCSS: String = ""
         private var lastBaseDirectory: URL?
         private var lastFileIdentifier: String?
-        private var prismJS: String?
-        private var mermaidJS: String?
-        private var katexJS: String?
-        private var katexAutoRenderJS: String?
         /// When true, ignore the next scroll event from JS (it's from a programmatic scroll).
         var suppressNextScroll = false
 
-        override init() {
-            if let prismURL = ResourceBundle.url(forResource: "prism-bundle.min", withExtension: "js", subdirectory: "Resources") {
-                do {
-                    prismJS = try String(contentsOf: prismURL, encoding: .utf8)
-                } catch {
-                    AppLogger.render.warning("Failed to load Prism.js bundle: \(error.localizedDescription)")
-                    AppLogger.breadcrumb("Prism.js load failed", category: "render", level: .warning)
-                }
-            } else {
-                AppLogger.render.warning("Prism.js bundle resource not found")
-                AppLogger.breadcrumb("Prism.js resource missing", category: "render", level: .warning)
-            }
+        // The JS bundles are immutable app resources — load them ONCE per process
+        // and share across all Coordinators (item-713 hang triage). Previously every
+        // Coordinator.init (one per tab, plus one per pane-toggle view recreation)
+        // synchronously re-read ~3.2 MB from disk on the main thread; mermaid.min.js
+        // alone is 2.9 MB, and Sentry hang report #48 sampled the main thread inside
+        // exactly that read. v1.7.0's restore-all-tabs (MV-001) multiplied the cost
+        // by the number of tabs opened during launch.
+        static let sharedJSBundles: (prism: String?, mermaid: String?, katex: String?, katexAutoRender: String?) = (
+            prism: loadJSBundle("prism-bundle.min", label: "Prism.js"),
+            mermaid: loadJSBundle("mermaid.min", label: "Mermaid.js"),
+            katex: loadJSBundle("katex.min", label: "KaTeX"),
+            katexAutoRender: loadJSBundle("auto-render.min", label: "KaTeX auto-render")
+        )
 
-            if let mermaidURL = ResourceBundle.url(forResource: "mermaid.min", withExtension: "js", subdirectory: "Resources") {
-                do {
-                    mermaidJS = try String(contentsOf: mermaidURL, encoding: .utf8)
-                } catch {
-                    AppLogger.render.warning("Failed to load Mermaid.js bundle: \(error.localizedDescription)")
-                    AppLogger.breadcrumb("Mermaid.js load failed", category: "render", level: .warning)
-                }
-            } else {
-                AppLogger.render.warning("Mermaid.js bundle resource not found")
-                AppLogger.breadcrumb("Mermaid.js resource missing", category: "render", level: .warning)
+        private static func loadJSBundle(_ name: String, label: String) -> String? {
+            guard let url = ResourceBundle.url(forResource: name, withExtension: "js", subdirectory: "Resources") else {
+                AppLogger.render.warning("\(label) bundle resource not found")
+                AppLogger.breadcrumb("\(label) resource missing", category: "render", level: .warning)
+                return nil
             }
-
-            if let katexURL = ResourceBundle.url(forResource: "katex.min", withExtension: "js", subdirectory: "Resources") {
-                do {
-                    katexJS = try String(contentsOf: katexURL, encoding: .utf8)
-                } catch {
-                    AppLogger.render.warning("Failed to load KaTeX bundle: \(error.localizedDescription)")
-                    AppLogger.breadcrumb("KaTeX load failed", category: "render", level: .warning)
-                }
-            } else {
-                AppLogger.render.warning("KaTeX bundle resource not found")
-                AppLogger.breadcrumb("KaTeX resource missing", category: "render", level: .warning)
-            }
-
-            if let arURL = ResourceBundle.url(forResource: "auto-render.min", withExtension: "js", subdirectory: "Resources") {
-                do {
-                    katexAutoRenderJS = try String(contentsOf: arURL, encoding: .utf8)
-                } catch {
-                    AppLogger.render.warning("Failed to load KaTeX auto-render bundle: \(error.localizedDescription)")
-                    AppLogger.breadcrumb("KaTeX auto-render load failed", category: "render", level: .warning)
-                }
-            } else {
-                AppLogger.render.warning("KaTeX auto-render bundle resource not found")
-                AppLogger.breadcrumb("KaTeX auto-render resource missing", category: "render", level: .warning)
+            do {
+                return try String(contentsOf: url, encoding: .utf8)
+            } catch {
+                AppLogger.render.warning("Failed to load \(label) bundle: \(error.localizedDescription)")
+                AppLogger.breadcrumb("\(label) load failed", category: "render", level: .warning)
+                return nil
             }
         }
+
+        private let prismJS = Coordinator.sharedJSBundles.prism
+        private let mermaidJS = Coordinator.sharedJSBundles.mermaid
+        private let katexJS = Coordinator.sharedJSBundles.katex
+        private let katexAutoRenderJS = Coordinator.sharedJSBundles.katexAutoRender
 
         // MARK: - Find Bar
 

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4271,6 +4271,35 @@ runner.test("MV-007: the ⌘T \"New Tab\" menu item opens an untitled tab, not t
 }
 
 // =============================================================================
+// MARK: - item-713 hang triage: JS bundles load once per process, not per Coordinator
+//
+// Sentry hang report #48 (issue paulhkang94/markview#48) sampled the main thread
+// inside Coordinator.init's synchronous mermaid.min.js read (2.9 MB, line 130 in
+// the v1.7.0 build). One Coordinator is created per tab (plus one per pane-toggle
+// view recreation), and v1.7.0's MV-001 restore-all-tabs reopens EVERY persisted
+// tab at launch — N tabs meant N x ~3.2 MB of duplicate synchronous main-thread
+// disk reads before first paint. The fix caches the four bundles in a per-process
+// static so the read happens exactly once. Source-inspection (Tier 4) is the only
+// harness that can reach the AppKit-only WebPreviewView target; behavioral
+// load-once coverage would need an injectable loader seam in the app target.
+
+runner.test("item-713: WebPreviewView JS bundles are cached in a process-wide static") {
+    let wpvSource = try String(contentsOfFile: "Sources/MarkView/WebPreviewView.swift", encoding: .utf8)
+    try expect(wpvSource.contains("static let sharedJSBundles"),
+        "WebPreviewView.Coordinator must define a static sharedJSBundles cache so the ~3.2 MB of JS bundles are read from disk once per process, not once per Coordinator instance")
+}
+
+runner.test("item-713: Coordinator.init no longer re-reads JS bundles from disk per instance") {
+    let wpvSource = try String(contentsOfFile: "Sources/MarkView/WebPreviewView.swift", encoding: .utf8)
+    try expect(!wpvSource.contains("override init()"),
+        "Coordinator's override init() — which performed four synchronous String(contentsOf:) disk reads on the main thread, the exact stack sampled in hang report #48 — must be gone; stored properties read from the static cache instead")
+    // Exactly ONE String(contentsOf: disk-read site may remain: the static loader helper.
+    let readCount = wpvSource.components(separatedBy: "String(contentsOf:").count - 1
+    try expect(readCount == 1,
+        "exactly one String(contentsOf: site must remain in WebPreviewView.swift (the static loadJSBundle helper); got \(readCount) — more than one means a per-instance read crept back in")
+}
+
+// =============================================================================
 
 print("")
 runner.summary()


### PR DESCRIPTION
Sentry hang report #48 sampled the main thread inside Coordinator.init's
synchronous mermaid.min.js read (2.9 MB, WebPreviewView.swift:130 in v1.7.0).
Every Coordinator (one per tab, plus one per pane-toggle recreation) re-read
~3.2 MB of immutable JS bundles from disk on the main actor, and v1.7.0's
restore-all-tabs (MV-001) multiplied that by the tab count during launch.

Load the four bundles exactly once per process into a static sharedJSBundles
cache; delete override init(). Two regression tests in TestRunner (red 346/2
before, green 348/348 after). Xcode app-target build verified (BUILD SUCCEEDED).

Triage doc: docs/personal/item-713-hang-triage-2026-07-13.md (issues #30,
#45-#48; follow-ups: off-main loadViaFileURL pipeline, lazy tab restore).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
