### PR TITLE
Release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.1
+
+- Fix app hangs on launch and tab restore (#55): the 3 MB of preview JS bundles (Mermaid, KaTeX, Prism) are now read once per process instead of once per tab, eliminating the main-thread stalls several users reported after v1.6/v1.7. If MarkView felt frozen with multiple restored tabs, this release is for you.
+- STATUS.md refreshed to current reality (#54); hook and CI housekeeping (#50-#53).
+
 ## v1.7.0
 
 - Restore all previously-open tabs on relaunch, not just the last one (MV-001, #39): reopening MarkView now brings back every tab from your last session, each with its own file watching and preview state.

--- a/Sources/MarkView/Info.plist
+++ b/Sources/MarkView/Info.plist
@@ -42,9 +42,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>323</string>
+	<string>330</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/MarkViewMCPServer/main.swift
+++ b/Sources/MarkViewMCPServer/main.swift
@@ -7,7 +7,7 @@ struct MarkViewMCPServer {
     static func main() async throws {
         let server = Server(
             name: "markview",
-            version: "1.7.0",
+            version: "1.7.1",
             capabilities: .init(
                 resources: .init(subscribe: false, listChanged: false),
                 tools: .init(listChanged: false)

--- a/Sources/MarkViewQuickLook/Info.plist
+++ b/Sources/MarkViewQuickLook/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>323</string>
+	<string>330</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSExtension</key>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-markview",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "MCP server for MarkView — preview Markdown files in a native macOS viewer",
   "license": "MIT",
   "author": "Paul Kang <contact@paulkang.dev>",

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -25,7 +25,7 @@ const GITHUB_REPO = "markview";
 // BINARY_VERSION pins the macOS app release to download.
 // This is intentionally decoupled from the npm package version —
 // npm patches (JS-only changes) don't require a new macOS binary release.
-const BINARY_VERSION = "1.7.0";
+const BINARY_VERSION = "1.7.1";
 const ARCHIVE_NAME = `MarkView-${BINARY_VERSION}.tar.gz`;
 const DOWNLOAD_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/v${BINARY_VERSION}/${ARCHIVE_NAME}`;
 

--- a/npm/server.json
+++ b/npm/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/paulhkang94/markview",
     "source": "github"
   },
-  "version": "1.7.0",
+  "version": "1.7.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "mcp-server-markview",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Hotfix release carrying the App Hanging fix (2d24426, item-713/mar-030): JS bundles cached process-wide instead of per Coordinator. 4 duplicate user hang reports post-v1.6/v1.7 during a 13.6x download spike.

Version bump across all 6 files + build 331 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)