### PR TITLE
fix(hang): move StatusBarView document stats off the main thread (item-713, 2nd class)

### DIFF
--- a/Sources/MarkView/StatusBarView.swift
+++ b/Sources/MarkView/StatusBarView.swift
@@ -13,6 +13,11 @@ struct StatusBarView: View {
 
     @State private var showLintPopover = false
 
+    // Computed off the main thread via .task(id:) below — the previous
+    // per-body-eval full-document scans here caused 2s+ main-thread hangs on
+    // large files (item-713).
+    @State private var stats = DocumentStats.zero
+
     init(content: String, filePath: String?, isDirty: Bool, lintWarnings: Int = 0, lintErrors: Int = 0, lintDiagnostics: [LintDiagnostic] = [], onFixAll: (() -> Void)? = nil) {
         self.content = content
         self.filePath = filePath
@@ -23,21 +28,8 @@ struct StatusBarView: View {
         self.onFixAll = onFixAll
     }
 
-    private var wordCount: Int {
-        content.split(whereSeparator: { $0.isWhitespace || $0.isNewline }).count
-    }
-
-    private var charCount: Int {
-        content.count
-    }
-
-    private var lineCount: Int {
-        content.isEmpty ? 0 : content.components(separatedBy: .newlines).count
-    }
-
     private var readingTime: String {
-        let minutes = max(1, wordCount / 200)
-        return "\(minutes) min read"
+        "\(stats.readingMinutes) min read"
     }
 
     var body: some View {
@@ -50,12 +42,12 @@ struct StatusBarView: View {
                     .accessibilityLabel(Strings.unsavedA11yLabel)
             }
 
-            Text(Strings.words(wordCount))
-                .accessibilityLabel(Strings.wordsA11y(wordCount))
-            Text(Strings.chars(charCount))
-                .accessibilityLabel(Strings.charsA11y(charCount))
-            Text(Strings.lines(lineCount))
-                .accessibilityLabel(Strings.linesA11y(lineCount))
+            Text(Strings.words(stats.wordCount))
+                .accessibilityLabel(Strings.wordsA11y(stats.wordCount))
+            Text(Strings.chars(stats.charCount))
+                .accessibilityLabel(Strings.charsA11y(stats.charCount))
+            Text(Strings.lines(stats.lineCount))
+                .accessibilityLabel(Strings.linesA11y(stats.lineCount))
             Text(readingTime)
                 .accessibilityLabel(Strings.readingTimeA11y(readingTime))
 
@@ -98,6 +90,13 @@ struct StatusBarView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 4)
         .background(.bar)
+        .task(id: content) {
+            let text = content
+            let computed = await Task.detached(priority: .utility) {
+                DocumentStats.compute(from: text)
+            }.value
+            stats = computed
+        }
     }
 }
 

--- a/Sources/MarkViewCore/DocumentStats.swift
+++ b/Sources/MarkViewCore/DocumentStats.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Word/character/line counts for the status bar, computed in a single pass.
+///
+/// Replaces three independent full-document scans (`split` for words,
+/// `components(separatedBy:)` for lines, plus a second word scan for reading
+/// time) that ran on the main thread inside `StatusBarView.body` and caused
+/// multi-second App Hanging events on large documents (item-713,
+/// Sentry APPLE-MACOS-34/-37).
+public struct DocumentStats: Equatable, Sendable {
+    public let wordCount: Int
+    public let charCount: Int
+    public let lineCount: Int
+
+    public init(wordCount: Int, charCount: Int, lineCount: Int) {
+        self.wordCount = wordCount
+        self.charCount = charCount
+        self.lineCount = lineCount
+    }
+
+    public static let zero = DocumentStats(wordCount: 0, charCount: 0, lineCount: 0)
+
+    /// Reading time in minutes at 200 wpm (minimum 1 for non-empty content).
+    public var readingMinutes: Int {
+        max(1, wordCount / 200)
+    }
+
+    /// Single-pass computation, parity-exact with the previous getters:
+    /// - words: runs of non-whitespace Characters (`Character.isWhitespace`
+    ///   already covers newlines)
+    /// - chars: Character (grapheme) count
+    /// - lines: newline *scalars* + 1, matching
+    ///   `components(separatedBy: .newlines).count` (CRLF counts as two)
+    public static func compute(from content: String) -> DocumentStats {
+        if content.isEmpty { return .zero }
+
+        let newlines = CharacterSet.newlines
+        var words = 0
+        var chars = 0
+        var newlineScalars = 0
+        var inWord = false
+
+        for ch in content {
+            chars += 1
+            if ch.isWhitespace {
+                if inWord {
+                    words += 1
+                    inWord = false
+                }
+            } else {
+                inWord = true
+            }
+            for scalar in ch.unicodeScalars where newlines.contains(scalar) {
+                newlineScalars += 1
+            }
+        }
+        if inWord { words += 1 }
+
+        return DocumentStats(
+            wordCount: words,
+            charCount: chars,
+            lineCount: newlineScalars + 1
+        )
+    }
+}

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4300,6 +4300,100 @@ runner.test("item-713: Coordinator.init no longer re-reads JS bundles from disk 
 }
 
 // =============================================================================
+// MARK: - item-713 (second hang class): StatusBarView main-thread document scans
+//
+// StatusBarView recomputed word/char/line counts with THREE independent
+// full-document scans on the main thread inside body — wordCount via split,
+// lineCount via components(separatedBy:), and readingTime re-running the word
+// split — on EVERY SwiftUI body evaluation. Symbolicated v1.7.0 hang reports
+// APPLE-MACOS-34 (wordCount.getter → Collection.split) and APPLE-MACOS-37
+// (lineCount.getter → StringProtocol.components) sampled these exact getters.
+// The fix: DocumentStats.compute() does ONE pass, and StatusBarView runs it
+// off-main via .task(id: content). The tests below pin parity with the
+// replaced getters, including their CRLF scalar-counting quirk.
+
+print("\n--- DocumentStats single-pass parity tests (item-713 StatusBarView hang) ---")
+
+runner.test("DocumentStats: empty content is all zeros (old lineCount special case)") {
+    let s = DocumentStats.compute(from: "")
+    try expect(s == DocumentStats.zero, "empty content must give 0/0/0, got \(s)")
+}
+
+runner.test("DocumentStats: basic words, chars, lines") {
+    let s = DocumentStats.compute(from: "hello world\nfoo")
+    try expect(s.wordCount == 3, "wordCount: expected 3, got \(s.wordCount)")
+    try expect(s.charCount == 15, "charCount: expected 15, got \(s.charCount)")
+    try expect(s.lineCount == 2, "lineCount: expected 2, got \(s.lineCount)")
+}
+
+runner.test("DocumentStats: runs of whitespace collapse into single word boundaries") {
+    let s = DocumentStats.compute(from: "  a\t\tb   c  \n\n d ")
+    try expect(s.wordCount == 4, "wordCount: expected 4, got \(s.wordCount)")
+    try expect(s.lineCount == 3, "lineCount: expected 3, got \(s.lineCount)")
+}
+
+runner.test("DocumentStats: trailing newline adds a line, not a word") {
+    let s = DocumentStats.compute(from: "abc\n")
+    try expect(s.wordCount == 1, "wordCount: expected 1, got \(s.wordCount)")
+    try expect(s.lineCount == 2, "lineCount: expected 2, got \(s.lineCount)")
+}
+
+runner.test("DocumentStats: CRLF counts two newline scalars — parity with components(separatedBy: .newlines)") {
+    // "a\r\nb" is 3 Characters but components(separatedBy: .newlines) yields
+    // ["a", "", "b"] because \r and \n are separate scalar separators. The
+    // single-pass version must preserve that (a perf fix must not change
+    // user-visible numbers).
+    let s = DocumentStats.compute(from: "a\r\nb")
+    try expect(s.charCount == 3, "charCount: expected 3 graphemes, got \(s.charCount)")
+    try expect(s.lineCount == 3, "lineCount: expected 3 (scalar parity), got \(s.lineCount)")
+    try expect(s.wordCount == 2, "wordCount: expected 2, got \(s.wordCount)")
+}
+
+runner.test("DocumentStats: parity with the replaced StatusBarView getters on varied samples") {
+    let samples = [
+        "# Title\n\nSome **bold** text with `code`.\n",
+        "one",
+        "émoji 🎉 café\nnaïve\r\nend",
+        "\n\n\n",
+        "a b c d e f g h i j",
+        String(repeating: "word ", count: 500) + "\n" + String(repeating: "line\n", count: 100),
+    ]
+    for content in samples {
+        let s = DocumentStats.compute(from: content)
+        let oldWords = content.split(whereSeparator: { $0.isWhitespace || $0.isNewline }).count
+        let oldChars = content.count
+        let oldLines = content.isEmpty ? 0 : content.components(separatedBy: .newlines).count
+        try expect(s.wordCount == oldWords,
+            "wordCount parity: expected \(oldWords), got \(s.wordCount) for \(content.prefix(30))…")
+        try expect(s.charCount == oldChars,
+            "charCount parity: expected \(oldChars), got \(s.charCount)")
+        try expect(s.lineCount == oldLines,
+            "lineCount parity: expected \(oldLines), got \(s.lineCount)")
+    }
+}
+
+runner.test("DocumentStats: readingMinutes matches the old max(1, words/200) formula") {
+    try expect(DocumentStats(wordCount: 0, charCount: 0, lineCount: 0).readingMinutes == 1,
+        "empty doc reads as 1 min (old formula)")
+    try expect(DocumentStats(wordCount: 199, charCount: 0, lineCount: 0).readingMinutes == 1,
+        "199 words -> 1 min")
+    try expect(DocumentStats(wordCount: 1000, charCount: 0, lineCount: 0).readingMinutes == 5,
+        "1000 words -> 5 min")
+}
+
+runner.test("item-713: StatusBarView no longer scans the document inside body") {
+    let source = try String(contentsOfFile: "Sources/MarkView/StatusBarView.swift", encoding: .utf8)
+    try expect(!source.contains(".split(whereSeparator:"),
+        "StatusBarView must not word-split the document on the main thread — that is the sampled hang stack (APPLE-MACOS-34)")
+    try expect(!source.contains("components(separatedBy:"),
+        "StatusBarView must not line-split the document on the main thread — that is the sampled hang stack (APPLE-MACOS-37)")
+    try expect(source.contains("DocumentStats.compute"),
+        "StatusBarView must delegate stats to DocumentStats.compute")
+    try expect(source.contains("Task.detached"),
+        "the DocumentStats computation must run off the main thread")
+}
+
+// =============================================================================
 
 print("")
 runner.summary()


### PR DESCRIPTION
Symbolicated v1.7.0 hang reports APPLE-MACOS-34 (wordCount.getter ->
Collection.split) and APPLE-MACOS-37 (lineCount.getter ->
StringProtocol.components) sampled StatusBarView's computed getters: three
independent full-document scans ran on the main thread inside body on every
SwiftUI re-evaluation (word split, line components, plus readingTime
re-running the word split). Multi-tab v1.6/v1.7 re-evaluates ContentView far
more often, and the 13.6x adoption spike surfaced the hot spot as GH #45-48.

Fix: DocumentStats (MarkViewCore) computes words/chars/lines in ONE pass;
StatusBarView holds it as @State and recomputes off-main via
.task(id: content) + Task.detached(priority: .utility). Parity with the old
getters is test-pinned, including the CRLF scalar-counting quirk of
components(separatedBy: .newlines).

Companion to PR #55 (JS-bundle caching), which fixed the other hang class
sampled in #48.

Test plan: 8 new TestRunner tests (parity suite + source-inspection guard
paired with behavioral coverage); full verify.py green (356 TestRunner,
Playwright, MCP, bundle).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
