### PR TITLE
fix(hang): move full-page assemble + temp-file write off the main thread (item-713, 3rd class, mar-028)

### DIFF
--- a/Sources/MarkView/WebPreviewView.swift
+++ b/Sources/MarkView/WebPreviewView.swift
@@ -396,6 +396,19 @@ struct WebPreviewView: NSViewRepresentable {
         /// (fileIdentifier may update before renderedHTML in separate @Published cycles).
         private var pendingFileReload = false
 
+        /// True while an async full-page load (assemble → temp-file write → loadFileURL)
+        /// is being prepared off-main. Content updates arriving in that window are routed
+        /// back through the full-reload path: a JS fast-path swap issued against the
+        /// outgoing page would be silently reverted the moment the in-flight loadFileURL
+        /// lands with its older snapshot (item-713 / mar-028).
+        private var fullReloadInFlight = false
+
+        /// Monotonic token for full-page loads: only the NEWEST prepared page may reach
+        /// loadFileURL. A stale completion (tab switch or live edit during preparation)
+        /// deletes its temp file and exits without touching the web view, so rapid
+        /// successive reloads always converge on the newest content.
+        private var loadGeneration = 0
+
         func updateContent(_ html: String, in webView: WKWebView) {
             let currentCSS = "\(Int(previewFontSize))|\(previewWidth)|\(theme)"
             let cssChanged = currentCSS != lastCSS
@@ -413,38 +426,74 @@ struct WebPreviewView: NSViewRepresentable {
             let baseDirChanged = baseDirectoryURL != lastBaseDirectory
             lastBaseDirectory = baseDirectoryURL
 
+            let contentChanged = html != lastHTML || cssChanged
             let needsFullReload = !hasLoadedInitialPage || baseDirChanged || pendingFileReload
+                || (fullReloadInFlight && contentChanged)
 
-            guard html != lastHTML || cssChanged || needsFullReload else { return }
+            guard contentChanged || needsFullReload else { return }
             lastHTML = html
 
             let styledHTML = injectSettingsCSS(into: html)
 
             if needsFullReload {
                 pendingFileReload = false
-                let fullHTML = pipeline.assemble(styledHTML)
-                loadViaFileURL(fullHTML, in: webView)
+                loadViaFileURL(styledHTML, in: webView)
                 hasLoadedInitialPage = true
             } else {
                 updateContentViaJS(styledHTML, in: webView)
             }
         }
 
-        /// Write HTML to a temp file and load via loadFileURL so WKWebView can access local images.
-        private func loadViaFileURL(_ html: String, in webView: WKWebView) {
-            var finalHTML = html
-            // Inline local images as data URIs: the sandboxed WKWebView WebContent process can't
-            // access files outside the app container even with allowingReadAccessTo. Embedding images
-            // in the HTML string eliminates the file access requirement entirely.
-            if let dir = baseDirectoryURL {
-                finalHTML = HTMLPipeline.inlineLocalImages(in: finalHTML, baseDirectory: dir)
+        /// Kick off a full page load: assemble the document, write it to a temp file,
+        /// and hand it to loadFileURL so WKWebView renders it as a real page.
+        ///
+        /// The assembly (string surgery over ~3.2 MB of injected JS bundles), image
+        /// inlining, and the synchronous temp-file write previously all ran on the
+        /// main thread here — the third item-713 hang class (mar-028). They now run
+        /// in a detached task (userInitiated — the user is watching the page load)
+        /// via PreviewPageBuilder (MarkViewCore);
+        /// only the completion touches the web view, back on the main actor.
+        private func loadViaFileURL(_ styledHTML: String, in webView: WKWebView) {
+            loadGeneration += 1
+            fullReloadInFlight = true
+            let generation = loadGeneration
+            let baseDir = baseDirectoryURL
+            let pipeline = self.pipeline
+            Task.detached(priority: .userInitiated) { [weak self] in
+                var tempFile: URL?
+                do {
+                    tempFile = try PreviewPageBuilder.assembleAndWrite(
+                        styledHTML: styledHTML,
+                        baseDirectory: baseDir,
+                        pipeline: pipeline
+                    )
+                } catch {
+                    AppLogger.render.error("Failed to write temp preview file: \(error.localizedDescription)")
+                    AppLogger.captureError(error, category: "render", message: "Temp file write failed")
+                }
+                await self?.finishFullPageLoad(tempFile, generation: generation)
             }
-            let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("markview-preview-\(UUID().uuidString).html")
-            do {
-                try finalHTML.write(to: tempFile, atomically: true, encoding: .utf8)
-            } catch {
-                AppLogger.render.error("Failed to write temp preview file: \(error.localizedDescription)")
-                AppLogger.captureError(error, category: "render", message: "Temp file write failed")
+        }
+
+        /// Main-actor completion of loadViaFileURL: hands the prepared temp file to
+        /// WKWebView. Ordering guarantee: a stale generation (a newer full load started
+        /// while this one was being prepared) never reaches the web view — it deletes
+        /// its temp file and exits, so tab switches and rapid edits always end on the
+        /// newest content, and renderComplete stays once-per-real-load (MV-002).
+        private func finishFullPageLoad(_ tempFile: URL?, generation: Int) {
+            guard generation == loadGeneration else {
+                // Superseded while preparing — discard without touching the web view.
+                if let tempFile { try? FileManager.default.removeItem(at: tempFile) }
+                return
+            }
+            // Write failed (already logged off-main): keep fullReloadInFlight true so
+            // the next content update retries the full-reload path instead of issuing
+            // a JS swap against a page that never loaded.
+            guard let tempFile else { return }
+            fullReloadInFlight = false
+            guard let webView else {
+                try? FileManager.default.removeItem(at: tempFile)
+                return
             }
             // Images are already inlined as data URIs, so WKWebView only needs access to the
             // temp directory. Never grant access to "/" or user home — least-privilege scope.

--- a/Sources/MarkViewCore/HTMLPipeline.swift
+++ b/Sources/MarkViewCore/HTMLPipeline.swift
@@ -18,7 +18,9 @@ enum PHKDebug {
 ///
 /// Extracted from WebPreviewView so the injection pipeline is testable
 /// without an AppKit dependency. All methods are pure String transformations.
-public struct HTMLPipeline {
+/// Sendable (all-String value type) so PreviewPageBuilder can assemble pages
+/// off the main actor (item-713 / mar-028).
+public struct HTMLPipeline: Sendable {
 
     public let prismJS: String?
     public let diff2htmlJS: String?

--- a/Sources/MarkViewCore/PreviewPageBuilder.swift
+++ b/Sources/MarkViewCore/PreviewPageBuilder.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Builds the full preview page (JS-injection assembly + optional local-image
+/// inlining) and writes it to a unique temp file for `WKWebView.loadFileURL`.
+///
+/// Extracted from `WebPreviewView.Coordinator` so the whole full-reload
+/// pipeline can run OFF the main thread (item-713 / mar-028, third hang
+/// class): `HTMLPipeline.assemble` performs string surgery over ~3.2 MB of
+/// injected JS bundles, image inlining reads files + base64-encodes them, and
+/// the temp-file write is synchronous disk I/O — all of which previously ran
+/// on the main actor inside `loadViaFileURL` on every full page reload
+/// (file open, tab switch, base-directory change).
+///
+/// Pure function of its inputs — safe to call from any thread or executor.
+/// The step order (assemble first, THEN inline images) is parity-exact with
+/// the replaced main-thread code path and is test-pinned.
+public enum PreviewPageBuilder {
+
+    /// Assemble the final HTML document and write it to a unique
+    /// `markview-preview-<uuid>.html` file inside `temporaryDirectory`.
+    ///
+    /// - Parameters:
+    ///   - styledHTML: template HTML with the per-view settings CSS already
+    ///     injected (the Coordinator does that cheap step on the main actor).
+    ///   - baseDirectory: when non-nil, relative image `src` attributes are
+    ///     inlined as data URIs (sandboxed WebContent can't read local files).
+    ///   - pipeline: the JS-injection pipeline (Prism → diff2html → Mermaid → KaTeX).
+    ///   - temporaryDirectory: injectable for tests; defaults to the process
+    ///     temp directory used by the shipping app.
+    /// - Returns: URL of the written temp file.
+    /// - Throws: any file-write error, so the caller can log and keep the
+    ///   reload retryable instead of silently loading a missing file.
+    public static func assembleAndWrite(
+        styledHTML: String,
+        baseDirectory: URL?,
+        pipeline: HTMLPipeline,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory
+    ) throws -> URL {
+        var finalHTML = pipeline.assemble(styledHTML)
+        // Inline local images as data URIs: the sandboxed WKWebView WebContent process
+        // can't access files outside the app container even with allowingReadAccessTo.
+        // Embedding images in the HTML string eliminates the file access requirement.
+        if let dir = baseDirectory {
+            finalHTML = HTMLPipeline.inlineLocalImages(in: finalHTML, baseDirectory: dir)
+        }
+        let tempFile = temporaryDirectory
+            .appendingPathComponent("markview-preview-\(UUID().uuidString).html")
+        try finalHTML.write(to: tempFile, atomically: true, encoding: .utf8)
+        return tempFile
+    }
+}

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4394,6 +4394,129 @@ runner.test("item-713: StatusBarView no longer scans the document inside body") 
 }
 
 // =============================================================================
+// MARK: - item-713 (third hang class) / mar-028: off-main full-page load pipeline
+//
+// The Coordinator's full-reload path ran HTMLPipeline.assemble (string surgery
+// over ~3.2 MB of injected JS), local-image inlining (file reads + base64), and
+// a synchronous temp-file write ON THE MAIN THREAD in loadViaFileURL on every
+// file open / tab switch / base-dir change. PreviewPageBuilder (MarkViewCore)
+// now owns that pipeline so the Coordinator can run it in a detached task and
+// only touch WKWebView back on the main actor, generation-guarded so rapid tab
+// switches always converge on the newest content. The behavioral tests below
+// read the written file back from disk (never just assert the call happened)
+// and pin byte-parity with the exact old main-thread sequence.
+
+print("\n--- PreviewPageBuilder tests (mar-028 off-main loadViaFileURL) ---")
+
+runner.test("PreviewPageBuilder: written file byte-equals pipeline.assemble output (disk read-back)") {
+    let pipeline = HTMLPipeline(prismJS: "var P=1;", mermaidJS: "var M=1;", katexJS: "var K=1;", katexAutoRenderJS: "var AR=1;")
+    let input = "<html><head></head><body><p>hello mar-028</p></body></html>"
+    let url = try PreviewPageBuilder.assembleAndWrite(styledHTML: input, baseDirectory: nil, pipeline: pipeline)
+    defer { try? FileManager.default.removeItem(at: url) }
+    let written = try String(contentsOf: url, encoding: .utf8)
+    try expect(written == pipeline.assemble(input),
+        "file content must byte-equal the assembled document — parity with the replaced main-thread path")
+    try expect(written.contains("var M=1;"),
+        "injected JS must be present in the written page")
+}
+
+runner.test("PreviewPageBuilder: unique markview-preview-*.html file per call (5s-delayed cleanup must never race a newer load)") {
+    let pipeline = HTMLPipeline()
+    let a = try PreviewPageBuilder.assembleAndWrite(styledHTML: "<body></body>", baseDirectory: nil, pipeline: pipeline)
+    let b = try PreviewPageBuilder.assembleAndWrite(styledHTML: "<body></body>", baseDirectory: nil, pipeline: pipeline)
+    defer {
+        try? FileManager.default.removeItem(at: a)
+        try? FileManager.default.removeItem(at: b)
+    }
+    try expect(a != b, "each load must get its own temp file, got the same URL twice")
+    try expect(a.lastPathComponent.hasPrefix("markview-preview-") && a.pathExtension == "html",
+        "temp filename contract markview-preview-<uuid>.html must hold, got \(a.lastPathComponent)")
+    try expect(FileManager.default.fileExists(atPath: a.path) && FileManager.default.fileExists(atPath: b.path),
+        "both temp files must exist on disk")
+}
+
+runner.test("PreviewPageBuilder: inlines relative local images, preserving the old order (assemble first, then inline)") {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("mar028-imgs-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try Data([0x89, 0x50, 0x4E, 0x47]).write(to: dir.appendingPathComponent("pic.png"))
+
+    let input = "<html><body><img src=\"pic.png\"></body></html>"
+    let pipeline = HTMLPipeline(mermaidJS: "var M=1;")
+    let url = try PreviewPageBuilder.assembleAndWrite(styledHTML: input, baseDirectory: dir, pipeline: pipeline)
+    defer { try? FileManager.default.removeItem(at: url) }
+    let written = try String(contentsOf: url, encoding: .utf8)
+    try expect(written.contains("data:image/png;base64,"),
+        "relative image src must be inlined as a data URI (sandboxed WebContent can't read local files)")
+    try expect(!written.contains("src=\"pic.png\""),
+        "the raw relative src must be gone after inlining")
+    // Order pin: byte-parity with the exact old main-thread sequence
+    // (pipeline.assemble in updateContent, THEN inlineLocalImages in loadViaFileURL).
+    let oldPath = HTMLPipeline.inlineLocalImages(in: pipeline.assemble(input), baseDirectory: dir)
+    try expect(written == oldPath,
+        "must preserve the replaced pipeline's step order: assemble first, then inline images")
+}
+
+runner.test("PreviewPageBuilder: nil baseDirectory leaves relative srcs untouched (old behavior)") {
+    let url = try PreviewPageBuilder.assembleAndWrite(
+        styledHTML: "<html><body><img src=\"pic.png\"></body></html>",
+        baseDirectory: nil,
+        pipeline: HTMLPipeline()
+    )
+    defer { try? FileManager.default.removeItem(at: url) }
+    let written = try String(contentsOf: url, encoding: .utf8)
+    try expect(written.contains("src=\"pic.png\""),
+        "no baseDirectory → no inlining, src must pass through unchanged")
+}
+
+runner.test("PreviewPageBuilder: unwritable temporaryDirectory throws — write failures must be observable") {
+    let bogus = URL(fileURLWithPath: "/nonexistent-mar028-\(UUID().uuidString)")
+    var threw = false
+    do {
+        _ = try PreviewPageBuilder.assembleAndWrite(
+            styledHTML: "<body></body>", baseDirectory: nil,
+            pipeline: HTMLPipeline(), temporaryDirectory: bogus
+        )
+    } catch {
+        threw = true
+    }
+    try expect(threw,
+        "writing into a nonexistent directory must throw so the Coordinator can log and keep the reload retryable")
+}
+
+runner.test("PreviewPageBuilder: UTF-8 disk round-trip is exact for multi-byte + CRLF content (determinism pin)") {
+    // Same determinism precedent as the DocumentStats CRLF scalar-parity pin:
+    // the written page must round-trip byte-exactly — no newline normalization
+    // (CRLF preserved) and no grapheme mangling for multi-scalar characters.
+    let input = "<html><body><p>émoji 🎉 café\r\nnaïve\nend\u{200D}</p></body></html>"
+    let pipeline = HTMLPipeline(prismJS: "var P=1;")
+    let url = try PreviewPageBuilder.assembleAndWrite(styledHTML: input, baseDirectory: nil, pipeline: pipeline)
+    defer { try? FileManager.default.removeItem(at: url) }
+    let written = try String(contentsOf: url, encoding: .utf8)
+    try expect(written == pipeline.assemble(input),
+        "multi-byte + CRLF content must round-trip byte-exactly through the temp file")
+    try expect(written.contains("\r\n"),
+        "CRLF must survive the disk round-trip un-normalized")
+}
+
+runner.test("mar-028: Coordinator no longer assembles or writes the page on the main thread") {
+    // Tier-4 source guard, paired with the behavioral disk read-back tests above.
+    let source = try String(contentsOfFile: "Sources/MarkView/WebPreviewView.swift", encoding: .utf8)
+    try expect(!source.contains("pipeline.assemble("),
+        "the Coordinator must not run HTMLPipeline.assemble on the main thread — that is the mar-028 hang path")
+    try expect(!source.contains(".write(to: tempFile"),
+        "the Coordinator must not perform the synchronous temp-file write on the main thread")
+    try expect(source.contains("PreviewPageBuilder.assembleAndWrite"),
+        "the Coordinator must delegate the full-page build to PreviewPageBuilder")
+    try expect(source.contains("Task.detached"),
+        "the page build must run off the main thread")
+    try expect(source.contains("loadGeneration"),
+        "stale prepared pages must be generation-guarded so tab switches always end on the newest content")
+    try expect(source.contains("fullReloadInFlight"),
+        "updates arriving while a full load is in flight must re-route through the full-reload path (JS swaps against the outgoing page get reverted)")
+}
+
+// =============================================================================
 
 print("")
 runner.summary()


### PR DESCRIPTION
The Coordinator's full-reload path ran three heavyweight steps on the main
thread in loadViaFileURL on every file open / tab switch / base-dir change:
HTMLPipeline.assemble (string surgery over ~3.2 MB of injected JS bundles),
local-image inlining (file reads + base64), and a synchronous temp-file
write. Follow-up to #55 (JS-bundle caching) and #57 (DocumentStats off-main),
which fixed the other two item-713 hang classes.

Fix: PreviewPageBuilder (MarkViewCore) owns the assemble → inline → write
pipeline as a pure, executor-agnostic function (step order parity-exact with
the replaced code and test-pinned). The Coordinator runs it in
Task.detached(priority: .userInitiated) and hands the temp file to
WKWebView.loadFileURL back on the main actor.

Ordering guarantees for tab switching / rapid edits, now that preparation is
async:
- loadGeneration token: only the newest prepared page may reach loadFileURL;
  stale completions delete their temp file and never touch the web view.
- fullReloadInFlight: content updates arriving while a load is being prepared
  re-route through the full-reload path - a JS fast-path swap issued against
  the outgoing page would be silently reverted when the in-flight loadFileURL
  landed with its older snapshot.
- renderCompleteFired reset + the 2s fallback timer move into the main-actor
  completion, right before loadFileURL, so renderComplete stays
  once-per-real-load (MV-002).
- On write failure the reload stays retryable (in-flight flag keeps the next
  update on the full-reload path) instead of loading a nonexistent file.

HTMLPipeline gains explicit Sendable (all-String value type) so it can cross
into the detached task.

Test plan: 7 new TestRunner tests (behavioral disk read-back parity suite
incl. CRLF/multi-byte determinism pin + image-inlining order pin, paired
with a source-inspection guard); suite 356 -> 363 green; Xcode app-target
Debug build verified; full verify.py green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
