### PR TITLE
fix(hang): guard StatusBarStatsModel publish on cancellation (item-713 / #57 follow-up)

### DIFF
--- a/Sources/MarkViewAppCore/StatusBarStatsModel.swift
+++ b/Sources/MarkViewAppCore/StatusBarStatsModel.swift
@@ -33,6 +33,13 @@ public final class StatusBarStatsModel: ObservableObject {
         let computed = await Task.detached(priority: .utility) {
             compute(content)
         }.value
+        // `.task(id: content)` cancels this task when the content changes, but the
+        // detached compute above does NOT inherit cancellation — it always runs to
+        // completion. Without this guard, two overlapping updates (rapid edits on a
+        // large document) can finish out of order and publish an OLDER document's
+        // counts over the newer ones. Bail on cancellation so only the newest
+        // (still-live) update writes `stats`.
+        guard !Task.isCancelled else { return }
         stats = computed
     }
 }

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4514,6 +4514,38 @@ runner.test("item-713/#57: StatusBarStatsModel default compute has exact Documen
     }
 }
 
+runner.test("item-713/#57: StatusBarStatsModel drops a cancelled update instead of publishing stale stats") {
+    // Regression: `.task(id: content)` cancels the in-flight update on every content
+    // change, but the detached compute does NOT inherit cancellation and always runs
+    // to completion. If the resumed (cancelled) update still published, an older
+    // document's counts could land AFTER a newer update's — a visible wrong word count
+    // during rapid edits. The cancellation guard must suppress the stale publish.
+    try MainActor.assumeIsolated {
+        let gate = LockedBox(false)
+        // compute blocks on a background thread until the test releases the gate,
+        // giving us a deterministic window to cancel mid-flight.
+        let model = StatusBarStatsModel(compute: { text in
+            while !gate.value { usleep(2000) }
+            return DocumentStats.compute(from: text)
+        })
+        try expect(model.stats == DocumentStats.zero, "precondition: model starts at .zero")
+
+        let task = Task { @MainActor in await model.update(for: "hello world with several words") }
+        // Let the detached compute start and block on the gate.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        task.cancel()          // simulate .task(id:) restart on a content change
+        gate.value = true      // release the compute so update() resumes (now cancelled)
+
+        // Drain: give the resumed update ample time to (wrongly) publish.
+        let deadline = Date().addingTimeInterval(3)
+        while model.stats == DocumentStats.zero && Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        try expect(model.stats == DocumentStats.zero,
+            "a cancelled update must NOT publish — got \(model.stats); the stale-write race (out-of-order overlapping updates) is back")
+    }
+}
+
 runner.test("item-713/#57 wiring: StatusBarView delegates stats to StatusBarStatsModel") {
     // Thin Tier-4 wiring check — the off-main mechanism is covered behaviorally
     // above; this only pins that the view actually uses the tested model and


### PR DESCRIPTION
StatusBarStatsModel.update(for:) is driven by StatusBarView's `.task(id: content)`,
which cancels the in-flight update on every content change and starts a fresh one.
But the `Task.detached(.utility)` compute inside update() does NOT inherit that
cancellation; it always runs to completion. With no cancellation guard before
`stats = computed`, two overlapping updates (rapid edits on a large document) can
finish OUT OF ORDER and publish an older document's word/char/line counts over the
newer ones, so the status bar transiently shows the wrong counts.

Add `guard !Task.isCancelled else { return }` after the detached compute resolves so
only the newest (still-live) update writes `stats`. The detached task is intentionally
not made cancellation-aware; letting it finish is cheap, and the fix is simply to not
publish its result once a newer update has superseded it.

Regression test (deterministic via a gated compute): start an update, cancel it while
the compute is blocked, release the compute, then assert nothing was published
(stats stays .zero). Verified test-first: it fails without the guard
(publishes wordCount:5) and passes with it. Suite 368 to 369 green; verify.py all checks passed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
