### PR TITLE
fix(hang): move PreviewViewModel.loadContent file read off the main thread (item-713, 4th class, mar-037)

### DIFF
--- a/Sources/MarkView/PreviewViewModel.swift
+++ b/Sources/MarkView/PreviewViewModel.swift
@@ -36,6 +36,12 @@ final class PreviewViewModel: ObservableObject {
     private var template: String?
     private var originalContent: String = ""
     private let linter = MarkdownLinter()
+    /// Monotonic token for loadContent (item-713 fourth hang class, mar-037):
+    /// only the NEWEST in-flight read may publish. A stale completion (a
+    /// newer loadFile/reloadFromDisk/watcher-triggered read started while an
+    /// older one was still on disk) is dropped instead of overwriting the
+    /// editor with older content — same pattern as mar-028's loadGeneration.
+    private var contentLoadGeneration = 0
     /// Suppresses file watcher reload during our own saves to prevent the watcher from
     /// reading back the file we just wrote and triggering a redundant (or racy) content reload.
     private var suppressFileWatcher = false
@@ -184,29 +190,44 @@ final class PreviewViewModel: ObservableObject {
         }
     }
 
+    /// Read `path` off the main thread (item-713 fourth hang class, mar-037 /
+    /// APPLE-MACOS-33) and publish the result on the main actor. Previously
+    /// this read the file's content synchronously, in-line, here — for a large
+    /// document, or a file on a slow/network volume, that blocks the main
+    /// thread for the duration of the read on every file open, external-change
+    /// reload, and file-watcher callback.
     private func loadContent(from path: String) {
-        // Resolve symlinks and normalize path to avoid file:// URL mismatches
-        let resolvedPath = (path as NSString).resolvingSymlinksInPath
-        let content: String
-        do {
-            content = try String(contentsOfFile: resolvedPath, encoding: .utf8)
-        } catch {
-            // Fallback: try original path in case resolution changed it incorrectly
+        contentLoadGeneration += 1
+        let generation = contentLoadGeneration
+        Task.detached(priority: .userInitiated) { [weak self] in
             do {
-                content = try String(contentsOfFile: path, encoding: .utf8)
+                let content = try FileContentLoader.read(from: path)
+                await self?.finishLoadContent(content, generation: generation)
             } catch {
-                AppLogger.file.error("Failed to load file at \(path): \(error.localizedDescription)")
-                AppLogger.captureError(error, category: "file", message: "File load failed: \(path)")
-                lastError = error
-                return
+                await self?.failLoadContent(error, path: path, generation: generation)
             }
         }
+    }
+
+    /// Main-actor completion of loadContent. Superseded reads (a newer
+    /// loadFile/reloadFromDisk/watcher-triggered call started while this one
+    /// was still on disk) are dropped so rapid successive reloads always
+    /// converge on the newest content instead of racing.
+    private func finishLoadContent(_ content: String, generation: Int) {
+        guard generation == contentLoadGeneration else { return }
         editorContent = content
         originalContent = content
         isDirty = false
         renderImmediate(content)
         runLint(content)
         isLoaded = true
+    }
+
+    private func failLoadContent(_ error: Error, path: String, generation: Int) {
+        guard generation == contentLoadGeneration else { return }
+        AppLogger.file.error("Failed to load file at \(path): \(error.localizedDescription)")
+        AppLogger.captureError(error, category: "file", message: "File load failed: \(path)")
+        lastError = error
     }
 
     private func renderImmediate(_ markdown: String) {

--- a/Sources/MarkViewCore/FileContentLoader.swift
+++ b/Sources/MarkViewCore/FileContentLoader.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Reads a markdown file's content from disk.
+///
+/// Extracted from `PreviewViewModel.loadContent` (item-713 fourth hang class,
+/// mar-037 / APPLE-MACOS-33): every file open (`loadFile`), external-change
+/// reload (`reloadFromDisk`), and file-watcher callback ran
+/// `String(contentsOfFile:)` synchronously on the main actor — for a large
+/// document, or a file on a slow/network volume, this blocks the main thread
+/// for the duration of the read. Same hang class already fixed for JS bundles
+/// (#55), doc stats (#57), and full-page assemble (mar-028/#59).
+///
+/// Pure function of its input — safe to call from any thread or executor.
+public enum FileContentLoader {
+
+    /// Read `path` as UTF-8 text.
+    ///
+    /// Resolves symlinks first (avoids `file://` URL mismatches with the
+    /// FileWatcher and WKWebView base-directory logic), then falls back to
+    /// the original, unresolved path if that read fails — parity with the
+    /// replaced main-thread code, which used the same two-step fallback.
+    ///
+    /// - Throws: the fallback-path read error if BOTH reads fail (matches the
+    ///   old behavior, which surfaced the original-path error to the caller).
+    public static func read(from path: String) throws -> String {
+        let resolvedPath = (path as NSString).resolvingSymlinksInPath
+        do {
+            return try String(contentsOfFile: resolvedPath, encoding: .utf8)
+        } catch {
+            return try String(contentsOfFile: path, encoding: .utf8)
+        }
+    }
+}

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4685,6 +4685,71 @@ runner.test("mar-028: Coordinator no longer assembles or writes the page on the 
 }
 
 // =============================================================================
+// MARK: - item-713 (fourth hang class) / mar-037 (APPLE-MACOS-33): off-main
+// PreviewViewModel.loadContent
+//
+// PreviewViewModel.loadContent ran String(contentsOfFile:) synchronously on
+// the main actor for every file open, external-change reload, and
+// file-watcher callback. FileContentLoader (MarkViewCore) now owns the read
+// (resolve-symlinks + fallback, parity-exact with the replaced code) so
+// PreviewViewModel can run it in a detached task and only publish the
+// @Published properties back on the main actor.
+
+print("\n--- FileContentLoader tests (mar-037 off-main loadContent) ---")
+
+runner.test("FileContentLoader: reads UTF-8 content exactly, including multi-byte + CRLF (determinism pin)") {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("mar037-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let file = dir.appendingPathComponent("doc.md")
+    let content = "émoji 🎉 café\r\nnaïve\nend\u{200D}"
+    try content.write(to: file, atomically: true, encoding: .utf8)
+
+    let read = try FileContentLoader.read(from: file.path)
+    try expect(read == content, "content must round-trip byte-exactly, including CRLF un-normalized")
+}
+
+runner.test("FileContentLoader: resolves symlinks — reading through a symlink returns the target's content") {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("mar037-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let real = dir.appendingPathComponent("real.md")
+    let link = dir.appendingPathComponent("link.md")
+    try "real content".write(to: real, atomically: true, encoding: .utf8)
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+
+    let read = try FileContentLoader.read(from: link.path)
+    try expect(read == "real content", "reading via a symlink must return the resolved target's content")
+}
+
+runner.test("FileContentLoader: throws when neither the resolved nor the original path exists") {
+    let bogus = FileManager.default.temporaryDirectory
+        .appendingPathComponent("mar037-nonexistent-\(UUID().uuidString).md").path
+    var threw = false
+    do {
+        _ = try FileContentLoader.read(from: bogus)
+    } catch {
+        threw = true
+    }
+    try expect(threw, "a missing file must throw so the caller can log and surface lastError instead of silently loading empty content")
+}
+
+runner.test("mar-037: PreviewViewModel no longer reads file content on the main thread") {
+    // Tier-4 source guard, paired with the behavioral FileContentLoader tests above
+    // (PreviewViewModel lives in the Xcode app target, not visible to TestRunner —
+    // same split as mar-028's PreviewPageBuilder/Coordinator pairing).
+    let source = try String(contentsOfFile: "Sources/MarkView/PreviewViewModel.swift", encoding: .utf8)
+    try expect(!source.contains("String(contentsOfFile:"),
+        "PreviewViewModel must not read file content directly — that is the mar-037 hang path (APPLE-MACOS-33)")
+    try expect(source.contains("FileContentLoader.read"),
+        "loadContent must delegate the disk read to FileContentLoader")
+    try expect(source.contains("Task.detached"),
+        "the file read must run off the main thread")
+    try expect(source.contains("contentLoadGeneration"),
+        "stale completions (a newer load started while an older read was in flight) must be generation-guarded so rapid reloads always end on the newest content")
+}
+
+// =============================================================================
 
 print("")
 runner.summary()


### PR DESCRIPTION
## Summary
- APPLE-MACOS-33 (App Hanging >=2000ms, production v1.7.1): `PreviewViewModel.loadContent` (`Sources/MarkView/PreviewViewModel.swift`) ran `String(contentsOfFile:)` synchronously on the main actor on every file open, external-change reload, and file-watcher callback — the 4th item-713 hang class, following #55 (JS bundles), #57 (doc stats), and mar-028/#59 (full-page assemble).
- Fix: `FileContentLoader.read` (`Sources/MarkViewCore/FileContentLoader.swift`) extracts the resolve-symlinks + fallback read as a pure, parity-exact function. `loadContent` now runs it in `Task.detached(priority: .userInitiated)` and publishes `editorContent`/`renderedHTML`/`lintDiagnostics` back on the main actor, with a `contentLoadGeneration` token (mirrors mar-028's `loadGeneration`) so a newer load always wins over a stale one still in flight.
- No call-site or signature changes — `loadFile`/`reloadFromDisk`/`watchFile` call `loadContent(from:)` exactly as before.

## Test plan
- [x] 3 new behavioral `FileContentLoader` tests (UTF-8/CRLF round-trip, symlink resolution, missing-file error)
- [x] 1 Tier-4 wiring test pinning off-main delegation + generation guard in `PreviewViewModel.swift` (app target, invisible to `MarkViewTestRunner` — same split as mar-028's PreviewPageBuilder/Coordinator pairing)
- [x] Ran red (372 passed / 1 failed) before the fix, green (373/373) after
- [x] Xcode app-target Release build (`bundle.sh --install`) verified
- [x] Full `python3 scripts/verify.py` green

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>