### PR TITLE
docs: fix cross-repo learnings pointer in GOTCHAS.md

### DIFF
--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -1,6 +1,6 @@
 # MarkView Gotchas
 
-Project-specific pitfalls and quirks. Cross-repo learnings go to `claude-repl-template-oss/docs/learnings/`.
+Project-specific pitfalls and quirks. Cross-repo learnings go to `claude-repl-template/docs/learnings/`.
 
 ### CMARK_OPT_SOURCEPOS changes all HTML output
 


### PR DESCRIPTION
claude-repl-template-oss does not exist; the learnings SSOT lives in
claude-repl-template/docs/learnings/.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
