### PR TITLE
mar-043: add sentry_check.py - scripted Sentry release close-gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ python3 scripts/test-hooks.py         # auto_install.py + render_verify_gate.py 
 python3 scripts/test-post-launch.py   # post_launch.py tests (10 tests, never opens a real browser tab)
 python3 scripts/test-github-parity-check.py  # github_parity_check.py tests (13 tests, no live GitHub API/swift build)
 python3 scripts/test-ci-status.py     # ci_status.py tests (24 tests, no live gh CLI)
+python3 scripts/test-sentry-check.py  # sentry_check.py tests (12 tests, no live Sentry API/Keychain)
 make playwright                       # Playwright e2e DOM tests (66 tests) — rebuilds MarkViewHTMLGen, runs Chromium
 ```
 

--- a/scripts/sentry_check.py
+++ b/scripts/sentry_check.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+sentry_check.py - query Sentry field telemetry for MarkView and run release close-gates.
+
+Replaces the ad-hoc curl + inline-python pattern used for the recurring
+"can we close the hang tracker yet?" checks (mar-043 and successors).
+
+Usage:
+    python3 scripts/sentry_check.py                       # unresolved issues, last 14d
+    python3 scripts/sentry_check.py --release 1.7.1       # issues with events on that release
+    python3 scripts/sentry_check.py --gate 1.7.1 --watch APPLE-MACOS-33,APPLE-MACOS-3B
+                                                          # close-gate verdict for a release
+    python3 scripts/sentry_check.py --json                # machine-readable output
+
+Token: macOS Keychain item SENTRY_AUTH_TOKEN (account "sentry"). Never passed
+via argv or exported env.
+
+Exit codes:
+    0  listing OK / gate PASS
+    1  gate FAIL (a watched group fired on the release, or release has no
+       field events yet - "no adoption" is indistinguishable from healthy,
+       so the gate refuses to pass on zero data)
+    2  auth/API/config error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ORG = "paulkang"
+PROJECT = "apple-macos"
+BASE = "https://sentry.io/api/0"
+
+
+def keychain_token() -> str | None:
+    result = subprocess.run(
+        [
+            "security",
+            "find-generic-password",
+            "-s",
+            "SENTRY_AUTH_TOKEN",
+            "-a",
+            "sentry",
+            "-w",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    token = result.stdout.strip()
+    return token if result.returncode == 0 and token else None
+
+
+class SentryAPI:
+    def __init__(self, token: str):
+        self._token = token
+
+    def get(self, path: str, params: dict | None = None) -> object:
+        url = f"{BASE}{path}"
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        req = urllib.request.Request(
+            url, headers={"Authorization": f"Bearer {self._token}"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.load(resp)
+
+
+def fetch_issues(
+    api: SentryAPI, query: str, stats_period: str | None = "14d"
+) -> list[dict]:
+    params: dict = {"query": query}
+    # Sentry rejects statsPeriod values other than '', '24h', '14d' on this endpoint;
+    # release-scoped queries use the default window (omit the param).
+    if stats_period:
+        params["statsPeriod"] = stats_period
+    data = api.get(f"/projects/{ORG}/{PROJECT}/issues/", params)
+    return data if isinstance(data, list) else []
+
+
+def latest_event_release(api: SentryAPI, issue_id: str) -> str:
+    try:
+        ev = api.get(f"/organizations/{ORG}/issues/{issue_id}/events/latest/")
+    except urllib.error.HTTPError:
+        return "?"
+    if not isinstance(ev, dict):
+        return "?"
+    rel = ev.get("release") or {}
+    return rel.get("version", "?") if isinstance(rel, dict) else "?"
+
+
+def issue_row(issue: dict, latest_release: str | None = None) -> dict:
+    return {
+        "shortId": issue.get("shortId", "?"),
+        "title": (issue.get("title") or "")[:70],
+        "culprit": (issue.get("culprit") or "")[:70],
+        "count": issue.get("count", "?"),
+        "firstSeen": (issue.get("firstSeen") or "")[:10],
+        "lastSeen": (issue.get("lastSeen") or "")[:10],
+        "latestEventRelease": latest_release,
+    }
+
+
+def release_report(api: SentryAPI, release: str) -> list[dict]:
+    issues = fetch_issues(api, f"release:{release}", stats_period=None)
+    return [issue_row(i, latest_event_release(api, str(i.get("id")))) for i in issues]
+
+
+def is_hang(row: dict) -> bool:
+    return "App Hanging" in (row.get("title") or "")
+
+
+def gate_verdict(rows: list[dict], release: str, watch: list[str]) -> dict:
+    """Close-gate semantics: PASS only if the release HAS field events (adoption)
+    AND no watched group fired on it AND no hang group's latest event is on it."""
+    watched_fired = [r for r in rows if r["shortId"] in watch]
+    live_hangs = [
+        r for r in rows if is_hang(r) and r.get("latestEventRelease") == release
+    ]
+    if not rows:
+        verdict = "NO_ADOPTION"
+    elif watched_fired or live_hangs:
+        verdict = "FAIL"
+    else:
+        verdict = "PASS"
+    return {
+        "release": release,
+        "verdict": verdict,
+        "watched_fired": [r["shortId"] for r in watched_fired],
+        "live_hang_groups": [
+            {"shortId": r["shortId"], "culprit": r["culprit"], "count": r["count"]}
+            for r in live_hangs
+        ],
+        "issues_with_release_events": len(rows),
+    }
+
+
+def format_rows(rows: list[dict]) -> str:
+    lines = []
+    for r in rows:
+        rel = (
+            f" | latest-release: {r['latestEventRelease']}"
+            if r.get("latestEventRelease")
+            else ""
+        )
+        lines.append(
+            f"{r['shortId']:<16} | {r['culprit'] or r['title']:<50} "
+            f"| count: {r['count']:>4} | {r['firstSeen']} -> {r['lastSeen']}{rel}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None, api: SentryAPI | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release", help="list issues with events on this release")
+    parser.add_argument(
+        "--gate", metavar="RELEASE", help="run close-gate verdict for a release"
+    )
+    parser.add_argument(
+        "--watch",
+        default="",
+        help="comma-separated Sentry shortIds that must NOT fire on the gated release",
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args(argv)
+
+    if api is None:
+        token = keychain_token()
+        if not token:
+            print(
+                "ERROR: SENTRY_AUTH_TOKEN not found in Keychain (account 'sentry')",
+                file=sys.stderr,
+            )
+            return 2
+        api = SentryAPI(token)
+
+    try:
+        if args.gate:
+            rows = release_report(api, args.gate)
+            watch = [w.strip() for w in args.watch.split(",") if w.strip()]
+            result = gate_verdict(rows, args.gate, watch)
+            if args.as_json:
+                print(json.dumps({"rows": rows, "gate": result}, indent=2))
+            else:
+                print(format_rows(rows))
+                print(
+                    f"\nGATE {result['verdict']} - release {args.gate}: "
+                    f"{result['issues_with_release_events']} issue group(s) with events, "
+                    f"watched fired: {result['watched_fired'] or 'none'}, "
+                    f"live hang groups: {[g['shortId'] for g in result['live_hang_groups']] or 'none'}"
+                )
+            return 0 if result["verdict"] == "PASS" else 1
+
+        if args.release:
+            rows = release_report(api, args.release)
+            print(json.dumps(rows, indent=2) if args.as_json else format_rows(rows))
+            return 0
+
+        issues = fetch_issues(api, "is:unresolved")
+        rows = [issue_row(i) for i in issues]
+        print(json.dumps(rows, indent=2) if args.as_json else format_rows(rows))
+        return 0
+    except urllib.error.HTTPError as e:
+        print(
+            f"ERROR: Sentry API {e.code}: {e.read().decode(errors='replace')[:200]}",
+            file=sys.stderr,
+        )
+        return 2
+    except urllib.error.URLError as e:
+        print(f"ERROR: Sentry API unreachable: {e.reason}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-sentry-check.py
+++ b/scripts/test-sentry-check.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Tests for sentry_check.py.
+
+Tier 2 behavioral tests - verify issue-row shaping, gate verdict logic, and
+exit codes against a fake SentryAPI. No live network, no Keychain access.
+
+Usage:
+    python3 scripts/test-sentry-check.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).parent
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _issue(
+    short_id,
+    title="App Hanging: App hanging for at least 2000 ms.",
+    culprit="X.y",
+    count="3",
+    iid="100",
+):
+    return {
+        "id": iid,
+        "shortId": short_id,
+        "title": title,
+        "culprit": culprit,
+        "count": count,
+        "firstSeen": "2026-07-06T00:00:00Z",
+        "lastSeen": "2026-07-29T00:00:00Z",
+    }
+
+
+class FakeAPI:
+    """Duck-typed stand-in for SentryAPI: path -> canned response."""
+
+    def __init__(self, issues=None, latest_releases=None):
+        self.issues = issues or []
+        self.latest_releases = latest_releases or {}
+
+    def get(self, path, params=None):
+        if path.endswith("/issues/") and "/projects/" in path:
+            return self.issues
+        for iid, rel in self.latest_releases.items():
+            if f"/issues/{iid}/events/latest/" in path:
+                return {"release": {"version": rel}}
+        return {}
+
+
+class TestIssueRow(unittest.TestCase):
+    def setUp(self):
+        self.m = _load("sentry_check")
+
+    def test_shapes_fields(self):
+        row = self.m.issue_row(_issue("APPLE-MACOS-2Z"), "1.7.1")
+        self.assertEqual(row["shortId"], "APPLE-MACOS-2Z")
+        self.assertEqual(row["firstSeen"], "2026-07-06")
+        self.assertEqual(row["lastSeen"], "2026-07-29")
+        self.assertEqual(row["latestEventRelease"], "1.7.1")
+
+    def test_tolerates_missing_fields(self):
+        row = self.m.issue_row({})
+        self.assertEqual(row["shortId"], "?")
+        self.assertEqual(row["culprit"], "")
+        self.assertIsNone(row["latestEventRelease"])
+
+
+class TestGateVerdict(unittest.TestCase):
+    def setUp(self):
+        self.m = _load("sentry_check")
+
+    def _rows(self, api, release="1.7.1"):
+        return self.m.release_report(api, release)
+
+    def test_no_adoption_fails(self):
+        result = self.m.gate_verdict([], "1.7.1", watch=[])
+        self.assertEqual(result["verdict"], "NO_ADOPTION")
+
+    def test_watched_group_fired_fails(self):
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-33", iid="1")], latest_releases={"1": "1.7.0"}
+        )
+        rows = self._rows(api)
+        result = self.m.gate_verdict(rows, "1.7.1", watch=["APPLE-MACOS-33"])
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertEqual(result["watched_fired"], ["APPLE-MACOS-33"])
+
+    def test_live_hang_group_fails_even_if_unwatched(self):
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"}
+        )
+        rows = self._rows(api)
+        result = self.m.gate_verdict(rows, "1.7.1", watch=[])
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertEqual(result["live_hang_groups"][0]["shortId"], "APPLE-MACOS-2Z")
+
+    def test_non_hang_issue_with_old_latest_release_passes(self):
+        api = FakeAPI(
+            issues=[
+                _issue("APPLE-MACOS-2", title="NSCocoaErrorDomain: Code: 260", iid="3")
+            ],
+            latest_releases={"3": "1.5.0"},
+        )
+        rows = self._rows(api)
+        result = self.m.gate_verdict(rows, "1.7.1", watch=["APPLE-MACOS-33"])
+        self.assertEqual(result["verdict"], "PASS")
+
+    def test_hang_with_older_latest_release_passes(self):
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"}
+        )
+        rows = self._rows(api)
+        result = self.m.gate_verdict(rows, "1.7.1", watch=[])
+        self.assertEqual(result["verdict"], "PASS")
+
+
+class TestMainExitCodes(unittest.TestCase):
+    def setUp(self):
+        self.m = _load("sentry_check")
+
+    def test_gate_fail_exits_1(self):
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"}
+        )
+        with patch("sys.stdout", new=StringIO()) as out:
+            rc = self.m.main(["--gate", "1.7.1"], api=api)
+        self.assertEqual(rc, 1)
+        self.assertIn("GATE FAIL", out.getvalue())
+
+    def test_gate_pass_exits_0(self):
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"}
+        )
+        with patch("sys.stdout", new=StringIO()) as out:
+            rc = self.m.main(["--gate", "1.7.1", "--watch", "APPLE-MACOS-33"], api=api)
+        self.assertEqual(rc, 0)
+        self.assertIn("GATE PASS", out.getvalue())
+
+    def test_no_adoption_exits_1(self):
+        api = FakeAPI(issues=[])
+        with patch("sys.stdout", new=StringIO()) as out:
+            rc = self.m.main(["--gate", "1.7.2"], api=api)
+        self.assertEqual(rc, 1)
+        self.assertIn("NO_ADOPTION", out.getvalue())
+
+    def test_unresolved_listing_exits_0(self):
+        api = FakeAPI(issues=[_issue("APPLE-MACOS-C", iid="5")])
+        with patch("sys.stdout", new=StringIO()) as out:
+            rc = self.m.main([], api=api)
+        self.assertEqual(rc, 0)
+        self.assertIn("APPLE-MACOS-C", out.getvalue())
+
+    def test_missing_token_exits_2(self):
+        mod = self.m
+        with patch.object(mod, "keychain_token", return_value=None):
+            with patch("sys.stderr", new=StringIO()):
+                rc = mod.main([])
+        self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -313,6 +313,7 @@ def tier_script_tests() -> bool:
         ("scripts/test-post-launch.py", "post_launch"),
         ("scripts/test-github-parity-check.py", "github_parity_check"),
         ("scripts/test-ci-status.py", "ci_status"),
+        ("scripts/test-sentry-check.py", "sentry_check"),
     ]
     all_passed = True
     for rel_path, label in suites:


### PR DESCRIPTION
Replaces the ad-hoc curl + inline-python pattern for the recurring
"close the hang tracker?" checks. `--gate RELEASE --watch IDS` fails
if a watched group fires on the release, any hang group's latest
event is on it, or the release has zero field events (no adoption).

- 12 behavioral tests (fake API, no network/Keychain)
- wired into verify.py script-test tier + CLAUDE.md test list
- live run 2026-07-30: GATE FAIL on 1.7.1 (2Z/3Q/31 live; 33+3B quiet)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
