### PR TITLE
fix: move markdown linting off main actor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
           APPROVED=(
             "docs/research/e2e-perf-testing-approaches.md"
             "docs/research/editor-bug-analysis.md"
+            "docs/research/markview-hang-triage-2026-08-12.md"
             "docs/research/ql-webview-sandbox-analysis.md"
             "docs/research/quicklook-extension-spm.md"
           )

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ docs/personal/
 docs/research/*
 !docs/research/e2e-perf-testing-approaches.md
 !docs/research/editor-bug-analysis.md
+!docs/research/markview-hang-triage-2026-08-12.md
 !docs/research/ql-webview-sandbox-analysis.md
 !docs/research/quicklook-extension-spm.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ python3 scripts/test-hooks.py         # auto_install.py + render_verify_gate.py 
 python3 scripts/test-post-launch.py   # post_launch.py tests (10 tests, never opens a real browser tab)
 python3 scripts/test-github-parity-check.py  # github_parity_check.py tests (13 tests, no live GitHub API/swift build)
 python3 scripts/test-ci-status.py     # ci_status.py tests (24 tests, no live gh CLI)
-python3 scripts/test-sentry-check.py  # sentry_check.py tests (12 tests, no live Sentry API/Keychain)
+python3 scripts/test-sentry-check.py  # sentry_check.py tests (14 tests, no live Sentry API/Keychain)
 make playwright                       # Playwright e2e DOM tests (66 tests) — rebuilds MarkViewHTMLGen, runs Chromium
 ```
 

--- a/Sources/MarkViewAppCore/PreviewViewModel.swift
+++ b/Sources/MarkViewAppCore/PreviewViewModel.swift
@@ -16,6 +16,8 @@ import MarkViewCore
 /// production logging behavior is unchanged. Tests get the default no-op.
 @MainActor
 public final class PreviewViewModel: ObservableObject {
+    public typealias LintOperation = @Sendable (String) -> [LintDiagnostic]
+
     @Published public var renderedHTML: String = ""
     @Published public var isLoaded: Bool = false
     @Published public var editorContent: String = ""
@@ -42,10 +44,12 @@ public final class PreviewViewModel: ObservableObject {
     private var fileWatcher: FileWatcher?
     private var renderTask: Task<Void, Never>?
     private var lintTask: Task<Void, Never>?
+    private var lintGeneration = 0
     private var autoSaveTimer: Timer?
     private var template: String?
     private var originalContent: String = ""
     private let linter = MarkdownLinter()
+    private let lintOperation: LintOperation
     /// Monotonic token for loadContent (item-713 fourth hang class, mar-037):
     /// only the NEWEST in-flight read may publish. A stale completion (a
     /// newer loadFile/reloadFromDisk/watcher-triggered read started while an
@@ -56,7 +60,11 @@ public final class PreviewViewModel: ObservableObject {
     /// reading back the file we just wrote and triggering a redundant (or racy) content reload.
     private var suppressFileWatcher = false
 
-    public init() {}
+    public init(lintOperation: @escaping LintOperation = { markdown in
+        MarkdownLinter().lint(markdown)
+    }) {
+        self.lintOperation = lintOperation
+    }
 
     public func loadFile(at path: String) {
         currentFilePath = path
@@ -166,6 +174,7 @@ public final class PreviewViewModel: ObservableObject {
         stopAutoSaveTimer()
         renderTask?.cancel()
         lintTask?.cancel()
+        lintGeneration += 1
         currentFilePath = nil
         fileName = "MarkView"
         renderedHTML = ""
@@ -257,19 +266,33 @@ public final class PreviewViewModel: ObservableObject {
     }
 
     private func lintDebounced(_ markdown: String) {
-        lintTask?.cancel()
-        lintTask = Task {
-            try? await Task.sleep(nanoseconds: 300_000_000) // 300ms debounce
-            guard !Task.isCancelled else { return }
-            runLint(markdown)
-        }
+        scheduleLint(markdown, debounceNanoseconds: 300_000_000)
     }
 
     private func runLint(_ markdown: String) {
-        let diagnostics = linter.lint(markdown)
-        lintDiagnostics = diagnostics
-        lintWarnings = diagnostics.filter { $0.severity == .warning }.count
-        lintErrors = diagnostics.filter { $0.severity == .error }.count
+        scheduleLint(markdown)
+    }
+
+    /// Markdown linting is CPU-bound and can be expensive for large documents.
+    /// Run it away from the main actor, then publish only the newest result.
+    private func scheduleLint(_ markdown: String, debounceNanoseconds: UInt64? = nil) {
+        lintTask?.cancel()
+        lintGeneration += 1
+        let generation = lintGeneration
+        let operation = lintOperation
+        lintTask = Task {
+            if let debounceNanoseconds {
+                try? await Task.sleep(nanoseconds: debounceNanoseconds)
+                guard !Task.isCancelled else { return }
+            }
+            let diagnostics = await Task.detached(priority: .userInitiated) {
+                operation(markdown)
+            }.value
+            guard !Task.isCancelled, generation == lintGeneration else { return }
+            lintDiagnostics = diagnostics
+            lintWarnings = diagnostics.filter { $0.severity == .warning }.count
+            lintErrors = diagnostics.filter { $0.severity == .error }.count
+        }
     }
 
     private func watchFile(at path: String) {

--- a/Sources/MarkViewCore/MarkdownLinter.swift
+++ b/Sources/MarkViewCore/MarkdownLinter.swift
@@ -2,8 +2,8 @@ import Foundation
 
 // MARK: - Diagnostic Types
 
-public struct LintDiagnostic: Equatable {
-    public enum Severity: String {
+public struct LintDiagnostic: Equatable, Sendable {
+    public enum Severity: String, Sendable {
         case warning, error
     }
 

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -4465,6 +4465,30 @@ runner.test("PreviewViewModel.loadFile: reads real file content off the main thr
     }
 }
 
+runner.test("PreviewViewModel linting runs off the main actor") {
+    try MainActor.assumeIsolated {
+        let slowLint: PreviewViewModel.LintOperation = { _ in
+            Thread.sleep(forTimeInterval: 0.4)
+            return []
+        }
+        let vm = PreviewViewModel(lintOperation: slowLint)
+        let started = Date()
+        vm.contentDidChange("**unclosed")
+
+        let mainActorStayedResponsive = drainMainActor(timeout: 1) {
+            // lintDebounced starts the injected 400ms operation after 300ms.
+            // At 350ms the main actor must still be able to resume this task.
+            try? await Task.sleep(nanoseconds: 350_000_000)
+        }
+        let elapsed = Date().timeIntervalSince(started)
+
+        try expect(mainActorStayedResponsive,
+            "main actor must remain responsive while lint computation runs")
+        try expect(elapsed < 0.55,
+            "350ms main-actor heartbeat was delayed by synchronous linting (elapsed: \(elapsed)s)")
+    }
+}
+
 runner.test("RecentFilesManager: recordOpen/removeFromRecents/clearAll round-trip through UserDefaults") {
     try MainActor.assumeIsolated {
         let (dir, files) = try makeTempMarkdownFiles(1, prefix: "mar038-recents")

--- a/docs/research/markview-hang-triage-2026-08-12.md
+++ b/docs/research/markview-hang-triage-2026-08-12.md
@@ -1,0 +1,39 @@
+# MarkView 1.7.1 hang triage - 2026-08-12
+
+## Scope
+
+Live Sentry review of the three 1.7.1 issue groups named in `mar-046`:
+`APPLE-MACOS-2Z`, `APPLE-MACOS-31`, and `APPLE-MACOS-3Q`.
+Evidence was refreshed with `scripts/sentry_check.py` on 2026-08-12 EDT.
+
+## Dispositions
+
+| Issue | Latest sample | Evidence | Disposition |
+|---|---:|---|---|
+| `APPLE-MACOS-2Z` | 2026-08-12 14:03 UTC | 72 events. The in-app stack contains only `main`, `MarkViewApp.$main`, and Sentry's hang monitor. It does not identify an app operation below the entry point. | Monitor. Do not make a speculative code change from this grouping alone. Revisit when a sample contains an actionable app frame. |
+| `APPLE-MACOS-31` | 2026-08-07 11:49 UTC | 8 events. The stack is `WebPreviewView.makeNSView` line 38 into `WKWebView.init`. WebKit construction is framework-required and already occurs through SwiftUI's `makeNSView` lifecycle. | Monitor. A reuse or pooling rewrite would add lifecycle risk without evidence that MarkView is constructing duplicate views. |
+| `APPLE-MACOS-3Q` | 2026-07-29 14:13 UTC | 1 event. The full app path reaches synchronous `MarkdownLinter.countOccurrences` from `PreviewViewModel.runLint` while the model is main-actor isolated. | Fixed. Lint computation now runs in a detached task, publishes only the newest generation on the main actor, and cancels stale/debounced publications. |
+
+## Fix verification
+
+The regression test injects a deterministic 400 ms lint operation, starts the
+normal 300 ms debounced lint path, and verifies that a 350 ms main-actor
+heartbeat is not delayed. It fails against the synchronous implementation and
+passes with the detached computation. `LintDiagnostic` and its severity are
+`Sendable` so results can safely cross back to the main actor.
+
+Focused result on 2026-08-12: `MarkViewTestRunner` - 382 passed, 0 failed.
+
+## Reusable telemetry improvement
+
+`scripts/sentry_check.py --issue [SHORT_ID] [--json]` now returns the latest
+event timestamp, release, and normalized in-app frames. This replaces repeated
+Keychain lookup, API calls, and ad hoc event-payload parsing during hang triage.
+It deliberately avoids printing the raw event payload.
+
+## Release follow-up
+
+- Ship the lint change in the next release after normal verification.
+- Watch all three issue groups against that release.
+- Treat a new `APPLE-MACOS-3Q` event on the fixed release as a regression.
+- Keep `APPLE-MACOS-2Z` and `APPLE-MACOS-31` open or muted according to alert-noise policy until a sample supplies a more actionable stack.

--- a/scripts/sentry_check.py
+++ b/scripts/sentry_check.py
@@ -8,6 +8,7 @@ Replaces the ad-hoc curl + inline-python pattern used for the recurring
 Usage:
     python3 scripts/sentry_check.py                       # unresolved issues, last 14d
     python3 scripts/sentry_check.py --release 1.7.1       # issues with events on that release
+    python3 scripts/sentry_check.py --issue APPLE-MACOS-2Z # latest event + in-app frames
     python3 scripts/sentry_check.py --gate 1.7.1 --watch APPLE-MACOS-33,APPLE-MACOS-3B
                                                           # close-gate verdict for a release
     python3 scripts/sentry_check.py --json                # machine-readable output
@@ -94,6 +95,55 @@ def latest_event_release(api: SentryAPI, issue_id: str) -> str:
     return rel.get("version", "?") if isinstance(rel, dict) else "?"
 
 
+def latest_event(api: SentryAPI, issue_id: str) -> dict:
+    data = api.get(f"/organizations/{ORG}/issues/{issue_id}/events/latest/")
+    return data if isinstance(data, dict) else {}
+
+
+def _stack_frames(event: dict) -> list[dict]:
+    """Return normalized in-app frames from exception and thread entries."""
+    frames: list[dict] = []
+    for entry in event.get("entries") or []:
+        if not isinstance(entry, dict) or entry.get("type") not in {"threads", "exception"}:
+            continue
+        values = (entry.get("data") or {}).get("values") or []
+        for value in values:
+            stack = value.get("stacktrace") if isinstance(value, dict) else None
+            for frame in (stack or {}).get("frames") or []:
+                if not isinstance(frame, dict) or not frame.get("inApp"):
+                    continue
+                frames.append(
+                    {
+                        "function": frame.get("function") or "?",
+                        "module": frame.get("module") or "",
+                        "filename": frame.get("filename") or "",
+                        "lineNo": frame.get("lineNo"),
+                    }
+                )
+    return frames
+
+
+def event_summary(event: dict) -> dict:
+    release = event.get("release") or {}
+    return {
+        "event_id": event.get("eventID") or event.get("id") or "?",
+        "timestamp": event.get("dateCreated") or event.get("dateReceived") or "?",
+        "release": release.get("version", "?") if isinstance(release, dict) else release,
+        "in_app_frames": _stack_frames(event),
+    }
+
+
+def issue_detail(api: SentryAPI, short_id: str) -> dict | None:
+    # Sentry's project-issues search does not accept `shortId:` as a query
+    # field. Fetch the bounded unresolved set and exact-match locally.
+    issues = fetch_issues(api, "is:unresolved")
+    issue = next((row for row in issues if row.get("shortId") == short_id), None)
+    if issue is None:
+        return None
+    event = latest_event(api, str(issue.get("id")))
+    return {"issue": issue_row(issue), "event": event_summary(event)}
+
+
 def issue_row(issue: dict, latest_release: str | None = None) -> dict:
     return {
         "shortId": issue.get("shortId", "?"),
@@ -155,9 +205,29 @@ def format_rows(rows: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def format_issue_detail(detail: dict) -> str:
+    issue = detail["issue"]
+    event = detail["event"]
+    lines = [
+        f"{issue['shortId']} | {issue['culprit'] or issue['title']} | count: {issue['count']}",
+        f"latest event: {event['timestamp']} | release: {event['release']}",
+        "in-app frames:",
+    ]
+    frames = event["in_app_frames"]
+    if not frames:
+        lines.append("  (none reported)")
+    for frame in frames:
+        location = frame["filename"]
+        if frame["lineNo"] is not None:
+            location += f":{frame['lineNo']}"
+        lines.append(f"  {frame['function']} | {frame['module']} | {location}")
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None, api: SentryAPI | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--release", help="list issues with events on this release")
+    parser.add_argument("--issue", metavar="SHORT_ID", help="show latest event stack summary")
     parser.add_argument(
         "--gate", metavar="RELEASE", help="run close-gate verdict for a release"
     )
@@ -180,6 +250,14 @@ def main(argv: list[str] | None = None, api: SentryAPI | None = None) -> int:
         api = SentryAPI(token)
 
     try:
+        if args.issue:
+            detail = issue_detail(api, args.issue)
+            if detail is None:
+                print(f"ERROR: Sentry issue {args.issue} not found", file=sys.stderr)
+                return 1
+            print(json.dumps(detail, indent=2) if args.as_json else format_issue_detail(detail))
+            return 0
+
         if args.gate:
             rows = release_report(api, args.gate)
             watch = [w.strip() for w in args.watch.split(",") if w.strip()]

--- a/scripts/test-sentry-check.py
+++ b/scripts/test-sentry-check.py
@@ -48,16 +48,22 @@ def _issue(
 class FakeAPI:
     """Duck-typed stand-in for SentryAPI: path -> canned response."""
 
-    def __init__(self, issues=None, latest_releases=None):
+    def __init__(self, issues=None, latest_releases=None, latest_events=None):
         self.issues = issues or []
         self.latest_releases = latest_releases or {}
+        self.latest_events = latest_events or {}
+        self.calls = []
 
     def get(self, path, params=None):
+        self.calls.append((path, params))
         if path.endswith("/issues/") and "/projects/" in path:
             return self.issues
         for iid, rel in self.latest_releases.items():
             if f"/issues/{iid}/events/latest/" in path:
                 return {"release": {"version": rel}}
+        for iid, event in self.latest_events.items():
+            if f"/issues/{iid}/events/latest/" in path:
+                return event
         return {}
 
 
@@ -170,6 +176,61 @@ class TestMainExitCodes(unittest.TestCase):
             with patch("sys.stderr", new=StringIO()):
                 rc = mod.main([])
         self.assertEqual(rc, 2)
+
+    def test_issue_detail_json_includes_actionable_frames(self):
+        event = {
+            "eventID": "evt-1",
+            "dateCreated": "2026-08-12T20:00:00Z",
+            "release": {"version": "1.7.1"},
+            "entries": [
+                {
+                    "type": "threads",
+                    "data": {
+                        "values": [
+                            {
+                                "stacktrace": {
+                                    "frames": [
+                                        {
+                                            "function": "CFRunLoopRun",
+                                            "module": "CoreFoundation",
+                                            "inApp": False,
+                                        },
+                                        {
+                                            "function": "MarkdownLinter.countOccurrences",
+                                            "module": "MarkViewCore",
+                                            "filename": "MarkdownLinter.swift",
+                                            "lineNo": 118,
+                                            "inApp": True,
+                                        },
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-3Q", iid="42")],
+            latest_events={"42": event},
+        )
+        with patch("sys.stdout", new=StringIO()) as out:
+            rc = self.m.main(["--issue", "APPLE-MACOS-3Q", "--json"], api=api)
+        self.assertEqual(rc, 0)
+        payload = __import__("json").loads(out.getvalue())
+        self.assertEqual(payload["issue"]["shortId"], "APPLE-MACOS-3Q")
+        self.assertEqual(payload["event"]["release"], "1.7.1")
+        self.assertEqual(
+            payload["event"]["in_app_frames"][0]["function"],
+            "MarkdownLinter.countOccurrences",
+        )
+        self.assertEqual(api.calls[0][1]["query"], "is:unresolved")
+
+    def test_issue_detail_missing_short_id_exits_1(self):
+        with patch("sys.stderr", new=StringIO()) as err:
+            rc = self.m.main(["--issue", "APPLE-MACOS-NOPE"], api=FakeAPI())
+        self.assertEqual(rc, 1)
+        self.assertIn("not found", err.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add issue-level Sentry stack inspection, document the 1.7.1 hang triage,
and prevent CPU-bound markdown linting from blocking the main actor.

Add a deterministic responsiveness regression test and stale-result guards.
