### PR TITLE
fix(mar-045): stub _which in golden-path bundle tests

### DIFF
--- a/scripts/test-bundle.py
+++ b/scripts/test-bundle.py
@@ -527,6 +527,9 @@ class TestGoldenCharacterization(unittest.TestCase):
             install_dir = tmp / "Applications/MarkView.app"
             mod._run = self._fake_run(tmp, install_dir)
             mod.LSREGISTER = Path(__file__)  # any real file → `.is_file()` True
+            # Never depend on a real xcodegen install — the CI "Verify" job
+            # (unlike "Bundle") doesn't install it, so this must be stubbed.
+            mod._which = lambda name: "/opt/homebrew/bin/xcodegen"
 
             out = []
             rc = mod.run_bundle(
@@ -567,6 +570,7 @@ class TestGoldenCharacterization(unittest.TestCase):
             self._make_project(tmp)
             install_dir = tmp / "Applications/MarkView.app"
             mod._run = self._fake_run(tmp, install_dir)
+            mod._which = lambda name: "/opt/homebrew/bin/xcodegen"
 
             out = []
             rc = mod.run_bundle(


### PR DESCRIPTION
## Summary
- Follow-up to #70 (already merged). Two `TestGoldenCharacterization` tests in `scripts/test-bundle.py` never stubbed `mod._which`, so they silently depended on this dev machine's real `xcodegen` install being on PATH.
- CI's "Verify" job (unlike "Bundle") never installs xcodegen — it only runs `python3 scripts/verify.py`. Because "Verify" isn't a required status check on `main` (only "Build & Test" and "Golden Drift Check" are), #70 auto-merged before this was caught, leaving `main`'s "Verify" CI job red.
- Fix: stub `mod._which` in both tests, matching every other happy-path test in the file. Reproduced the failure locally with `PATH=/usr/bin:/bin python3 scripts/test-bundle.py` before fixing, and confirmed it now passes in that same stripped-PATH environment.

## Test plan
- [x] `PATH=/usr/bin:/bin python3 scripts/test-bundle.py` (simulates CI's "Verify" job, no xcodegen on PATH) — 32/32 passing
- [x] `python3 scripts/test-bundle.py` (normal local env) — 32/32 passing
- [x] `ruff check scripts/test-bundle.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)