### PR TITLE
Release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 
-## Unreleased
+## v1.7.2
 
+- Fix a Markdown-lint main-thread hang (#69): the live linter ran synchronously on the main actor on every keystroke, so a large document could freeze typing. Linting now runs off the main thread with generation/cancellation guards and a deterministic heartbeat regression test.
 - Fix a fourth app hang class (#62): the preview pane read file content synchronously on the main thread on every file open, external-change reload, and file-watcher callback. A large file, or one on a slow or network volume, could freeze the window during that read. The read now happens off the main thread.
 - Fix a third app hang class (#59): assembling the full preview page and writing it to a temp file happened synchronously on the main thread on every tab switch and reload. A large document with many inline images could freeze the window during that write. Now off the main thread.
 - Fix a race in the v1.7.1 status bar hang fix (#61): rapid edits on a large document could publish stale word and line counts if an older background computation finished after a newer one started. Cancelled computations are now dropped instead of published.
-- Internal: extract the app's hang-fix logic (JS bundle cache, status bar stats, tab management, file loading, recent files, settings, and error presentation) into a new MarkViewAppCore library so it runs under the automated test suite instead of relying on manual verification or source-text checks (#60, mar-038).
+- Internal: extract the app's hang-fix logic (JS bundle cache, status bar stats, tab management, file loading, recent files, settings, and error presentation) into a new MarkViewAppCore library so it runs under the automated test suite instead of relying on manual verification or source-text checks (#60, #63, mar-033/mar-038).
 - Internal: add a CI-advisory GUI launch canary (mar-039) that launches the real built app and waits for a sentinel the restore-loop only prints once every tab finishes loading, so a regression that reintroduces a main-thread hang on that path shows up as a timed-out launch instead of only a simulated budget test.
 - Internal: migrate six bash scripts with real branching/parsing logic (auto-install.sh, render-verify-gate.sh, check-rule-gates.sh, post-launch.sh, github-parity-check.sh, ci-status.sh) to tested Python, following the existing metrics.py/check_traction.py pattern; each keeps its `.sh` name as a thin exec-delegating wrapper so no CI workflow, hook config, or doc callsite had to change (item-663).
+- Internal: add `scripts/sentry_check.py` (mar-043), a scripted Sentry release close-gate that normalizes the latest event's in-app frames for issue triage.
+- Internal: surface the real `xcodebuild`/`swift build` root cause when `bundle.sh` fails instead of a generic error (mar-026, #68); migrate `bundle.sh` to tested Python as `scripts/bundle.py`, with `bundle.sh` reduced to a 3-line exec wrapper (mar-045, #70, #71).
 
 ## v1.7.1
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-cmark", from: "0.4.0"),
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.10.0"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
     ],
     targets: [
         // Core library with renderer and file watcher (no UI dependencies for testability)

--- a/Sources/MarkView/Info.plist
+++ b/Sources/MarkView/Info.plist
@@ -42,9 +42,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.7.2</string>
 	<key>CFBundleVersion</key>
-	<string>330</string>
+	<string>346</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/MarkViewMCPServer/main.swift
+++ b/Sources/MarkViewMCPServer/main.swift
@@ -7,7 +7,7 @@ struct MarkViewMCPServer {
     static func main() async throws {
         let server = Server(
             name: "markview",
-            version: "1.7.1",
+            version: "1.7.2",
             capabilities: .init(
                 resources: .init(subscribe: false, listChanged: false),
                 tools: .init(listChanged: false)

--- a/Sources/MarkViewQuickLook/Info.plist
+++ b/Sources/MarkViewQuickLook/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.7.2</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>330</string>
+	<string>346</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSExtension</key>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-markview",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "MCP server for MarkView — preview Markdown files in a native macOS viewer",
   "license": "MIT",
   "author": "Paul Kang <contact@paulkang.dev>",

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -25,7 +25,7 @@ const GITHUB_REPO = "markview";
 // BINARY_VERSION pins the macOS app release to download.
 // This is intentionally decoupled from the npm package version —
 // npm patches (JS-only changes) don't require a new macOS binary release.
-const BINARY_VERSION = "1.7.1";
+const BINARY_VERSION = "1.7.2";
 const ARCHIVE_NAME = `MarkView-${BINARY_VERSION}.tar.gz`;
 const DOWNLOAD_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/v${BINARY_VERSION}/${ARCHIVE_NAME}`;
 

--- a/npm/server.json
+++ b/npm/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/paulhkang94/markview",
     "source": "github"
   },
-  "version": "1.7.1",
+  "version": "1.7.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "mcp-server-markview",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Version bump 1.7.1 -> 1.7.2 (patch: bug fixes + internal tooling, no new user-facing feature) across all 6 version files.
- CHANGELOG.md: v1.7.2 section covering the Markdown-lint main-thread hang fix (#69) plus the 13 commits shipped since v1.7.1 (hang fixes, MarkViewAppCore extraction, GUI launch canary, bash->Python script migrations, sentry_check.py release gate, bundle.sh->bundle.py migration).
- Bump `swift-sdk` (MCP SDK) dependency constraint from `0.10.0` to `0.12.0`: the pinned 0.10.2 `NetworkTransport` hits a hard Swift 6.3.3 strict-concurrency compile error ("sending risks causing data races") that blocks the pre-push local-build gate for every release from this toolchain. Confirmed pre-existing on main and unrelated to this release's other changes. Upstream fixed the same pattern by 0.12.1. MCP test suite (28/28 groups, 99 protocol tests) and full app bundle build verified green against 0.12.1.

## Test plan
- [x] `python3 scripts/check_version_sync.py` - all 6 files in sync at 1.7.2
- [x] `python3 scripts/verify.py` - 382 Swift tests, 4 PDF tests, golden drift clean, all script suites (incl. sentry_check, bundle) pass
- [x] `bash scripts/test-mcp.sh` - 28/28 test groups, 99 protocol tests pass against swift-sdk 0.12.1
- [x] `bash scripts/bundle.sh --install` - full app + MCP server build/install succeeds