### PR TITLE
feat(sentry): add --raw event dump to sentry_check.py (APPLE-MACOS-4J triage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Internal: `scripts/sentry_check.py --issue SHORT_ID --raw` prints the untouched latest event JSON through the existing Keychain-authenticated read-only client, so hang triage that needs thread state, `contexts`, tags, or breadcrumbs stays on the tested path instead of an ad-hoc curl script (mar-043 follow-up). The dump is not redacted; see the script docstring before sharing it.
+- Internal: record the root cause of the v1.7.2 `APPLE-MACOS-4J` main-thread render hang in `docs/STATUS.md`. Reproduced and root-caused, fix deferred to its own PR.
+
 ## v1.7.2
 
 - Fix a Markdown-lint main-thread hang (#69): the live linter ran synchronously on the main actor on every keystroke, so a large document could freeze typing. Linting now runs off the main thread with generation/cancellation guards and a deterministic heartbeat regression test.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,6 +22,44 @@ pending work, and key architectural decisions.
 - Headline changes: tab system (MV-001 restore-all-tabs, MV-002 renderComplete, MV-003/MV-005 per-tab scroll restore, MV-007 ⌘T untitled tabs, MV-009 ⌃Tab cycling), release scripts → Python, npm OIDC trusted publishing + automatic MCP registry publish, dSYM upload to Sentry (v1.7.0 is the first release with symbolicated crash/hang reports).
 - **Open issues**: 6 (as of 2026-07-13) - 5 are Sentry-auto-filed "App Hanging ≥2000 ms" reports (#30, #45-#48); triage + first fix: `docs/personal/item-713-hang-triage-2026-07-13.md`, branch `fix/item-713-js-bundle-cache`. The 6th is enhancement #26 (remember window position).
 
+### Known unfixed hang: APPLE-MACOS-4J (v1.7.2, triaged 2026-09-07)
+
+v1.7.2 has a reproduced, root-caused, **unfixed** main-thread hang. Recorded here
+so the next maintainer does not re-derive it.
+
+- **What**: Sentry App Hang (>= 2000 ms main-thread block), 1 event, first seen
+  2026-09-03, latest event on release 1.7.2. `python3 scripts/sentry_check.py --gate 1.7.2`
+  fails on it as a live hang group. The Sentry group title is `xrealloc`, which is
+  only the innermost frame, not the cause.
+- **Root cause**: the markdown render still runs synchronously on the MainActor.
+  Sampled thread 0, innermost last:
+  `PreviewViewModel.loadContent` (`PreviewViewModel.swift:226`) ->
+  `finishLoadContent` (`:242`) -> `renderImmediate` (`:255`) ->
+  `MarkdownRenderer.renderHTML` (`MarkdownRenderer.swift:30`) -> cmark
+  `cmark_render_html` -> `escape_html` -> `cmark_strbuf_grow` -> `xrealloc`.
+  All four source line numbers were checked against the v1.7.2 tree and match exactly.
+- **Family**: this is the next member of the sequence mar-037 (file read off main)
+  and #69 (linting off main). Each fix moved one piece of the document-load path
+  off the main actor and left the next one behind. It is **not** a #69 regression:
+  `runLint` is called at `:243`, after the hung `renderImmediate` at `:242`, and no
+  lint frames appear on the stack.
+- **Reproduced**: a release build of the same `MarkViewCore` render path crosses
+  2000 ms in a single render on two realistic document shapes (a 9.7 MB
+  escape-dense document at 2.46 s, a 4.5 MB GFM table at 2.25 s). `CMARK_OPT_SOURCEPOS`
+  (`MarkdownRenderer.swift:12`) inflates output roughly 9x on node-dense input and is
+  the largest single lever on render cost.
+- **Ruled out**: memory pressure (61.8 MB app memory, 5.5 GB free, thermal nominal),
+  WebKit (`WebCore: Scrolling` is a different thread), swift-markdown (not on this
+  path - the renderer is swift-cmark), and cmark lock contention (registration is
+  `CMARK_RUN_ONCE`).
+- **Fix deferred to its own PR**: moving `renderHTML` to a detached task with a
+  generation guard (mirroring `scheduleLint` at `PreviewViewModel.swift:275-296`)
+  is under 50 lines but is not mechanical - `isLoaded` is set on the line after
+  `renderImmediate`, so an async render needs a new loading-state contract, which
+  is a product decision plus an `--extended` verify run.
+- Full evidence, breadcrumb timeline, and hypothesis ranking: `docs/personal/hang-4j-triage-2026-09-07.md`
+  (untracked - the raw event payload is unredacted field data).
+
 > **BINARY_VERSION contract**: `postinstall.js` BINARY_VERSION points to the last
 > successfully notarized GitHub Release binary. npm patches (JS wrapper changes) do
 > NOT bump BINARY_VERSION. App releases ALWAYS bump it: `release.sh --bump` updates

--- a/docs/research/markview-hang-triage-2026-08-12.md
+++ b/docs/research/markview-hang-triage-2026-08-12.md
@@ -29,7 +29,19 @@ Focused result on 2026-08-12: `MarkViewTestRunner` - 382 passed, 0 failed.
 `scripts/sentry_check.py --issue [SHORT_ID] [--json]` now returns the latest
 event timestamp, release, and normalized in-app frames. This replaces repeated
 Keychain lookup, API calls, and ad hoc event-payload parsing during hang triage.
-It deliberately avoids printing the raw event payload.
+The summary path deliberately avoids printing the raw event payload.
+
+> **Amended 2026-09-07.** That is still true of the default `--issue` output, but
+> it is no longer the only mode. Triaging `APPLE-MACOS-4J` needed thread state,
+> `contexts`, tags, and breadcrumbs, none of which survive the summary, so
+> `--issue [SHORT_ID] --raw` was added as an opt-in full dump of the untouched
+> event.
+>
+> **`--raw` output is not redacted.** A Sentry macOS event can carry the
+> reporter's IP address (`user.ip_address`), device name and model
+> (`contexts.device`), tags, and absolute filesystem paths in breadcrumbs and
+> stack frames. Read it in the terminal. Never paste it into a tracked file, an
+> issue, or a pull request body - this repository is public.
 
 ## Release follow-up
 

--- a/scripts/sentry_check.py
+++ b/scripts/sentry_check.py
@@ -9,12 +9,22 @@ Usage:
     python3 scripts/sentry_check.py                       # unresolved issues, last 14d
     python3 scripts/sentry_check.py --release 1.7.1       # issues with events on that release
     python3 scripts/sentry_check.py --issue APPLE-MACOS-2Z # latest event + in-app frames
+    python3 scripts/sentry_check.py --issue APPLE-MACOS-2Z --raw
+                                                          # untouched latest-event JSON
     python3 scripts/sentry_check.py --gate 1.7.1 --watch APPLE-MACOS-33,APPLE-MACOS-3B
                                                           # close-gate verdict for a release
     python3 scripts/sentry_check.py --json                # machine-readable output
 
 Token: macOS Keychain item SENTRY_AUTH_TOKEN (account "sentry"). Never passed
 via argv or exported env.
+
+PRIVACY - `--raw` output is not redacted. A Sentry macOS event can carry the
+reporter's IP address (`user.ip_address`), device name and model
+(`contexts.device`), tags, and absolute filesystem paths in breadcrumbs and
+stack frames. Read it in the terminal only. Never paste raw output into a
+tracked file, an issue, or a pull request body - this is a public repository.
+The default (non-`--raw`) `--issue` summary keeps only normalized in-app frames
+and carries none of that.
 
 Exit codes:
     0  listing OK / gate PASS
@@ -65,12 +75,16 @@ class SentryAPI:
         url = f"{BASE}{path}"
         if params:
             url += "?" + urllib.parse.urlencode(params)
-        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {self._token}"})
+        req = urllib.request.Request(
+            url, headers={"Authorization": f"Bearer {self._token}"}
+        )
         with urllib.request.urlopen(req, timeout=30) as resp:
             return json.load(resp)
 
 
-def fetch_issues(api: SentryAPI, query: str, stats_period: str | None = "14d") -> list[dict]:
+def fetch_issues(
+    api: SentryAPI, query: str, stats_period: str | None = "14d"
+) -> list[dict]:
     params: dict = {"query": query}
     # Sentry rejects statsPeriod values other than '', '24h', '14d' on this endpoint;
     # release-scoped queries use the default window (omit the param).
@@ -171,7 +185,9 @@ def gate_verdict(rows: list[dict], release: str, watch: list[str]) -> dict:
     """Close-gate semantics: PASS only if the release HAS field events (adoption)
     AND no watched group fired on it AND no hang group's latest event is on it."""
     watched_fired = [r for r in rows if r["shortId"] in watch]
-    live_hangs = [r for r in rows if is_hang(r) and r.get("latestEventRelease") == release]
+    live_hangs = [
+        r for r in rows if is_hang(r) and r.get("latestEventRelease") == release
+    ]
     if not rows:
         verdict = "NO_ADOPTION"
     elif watched_fired or live_hangs:
@@ -193,7 +209,11 @@ def gate_verdict(rows: list[dict], release: str, watch: list[str]) -> dict:
 def format_rows(rows: list[dict]) -> str:
     lines = []
     for r in rows:
-        rel = f" | latest-release: {r['latestEventRelease']}" if r.get("latestEventRelease") else ""
+        rel = (
+            f" | latest-release: {r['latestEventRelease']}"
+            if r.get("latestEventRelease")
+            else ""
+        )
         lines.append(
             f"{r['shortId']:<16} | {r['culprit'] or r['title']:<50} "
             f"| count: {r['count']:>4} | {r['firstSeen']} -> {r['lastSeen']}{rel}"
@@ -224,7 +244,9 @@ def main(argv: list[str] | None = None, api: SentryAPI | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--release", help="list issues with events on this release")
     parser.add_argument("--issue", metavar="SHORT_ID", help="show latest event stack summary")
-    parser.add_argument("--gate", metavar="RELEASE", help="run close-gate verdict for a release")
+    parser.add_argument(
+        "--gate", metavar="RELEASE", help="run close-gate verdict for a release"
+    )
     parser.add_argument(
         "--watch",
         default="",
@@ -234,10 +256,13 @@ def main(argv: list[str] | None = None, api: SentryAPI | None = None) -> int:
     parser.add_argument(
         "--raw",
         action="store_true",
-        help="with --issue: print the untouched latest-event JSON "
-        "(thread state, contexts, tags, breadcrumbs). Read-only.",
+        help="requires --issue: print the untouched latest-event JSON "
+        "(thread state, contexts, tags, breadcrumbs). Read-only, but NOT "
+        "redacted - may contain user IP, device name, and absolute paths.",
     )
     args = parser.parse_args(argv)
+    if args.raw and not args.issue:
+        parser.error("--raw requires --issue SHORT_ID")
 
     if api is None:
         token = keychain_token()

--- a/scripts/sentry_check.py
+++ b/scripts/sentry_check.py
@@ -65,16 +65,12 @@ class SentryAPI:
         url = f"{BASE}{path}"
         if params:
             url += "?" + urllib.parse.urlencode(params)
-        req = urllib.request.Request(
-            url, headers={"Authorization": f"Bearer {self._token}"}
-        )
+        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {self._token}"})
         with urllib.request.urlopen(req, timeout=30) as resp:
             return json.load(resp)
 
 
-def fetch_issues(
-    api: SentryAPI, query: str, stats_period: str | None = "14d"
-) -> list[dict]:
+def fetch_issues(api: SentryAPI, query: str, stats_period: str | None = "14d") -> list[dict]:
     params: dict = {"query": query}
     # Sentry rejects statsPeriod values other than '', '24h', '14d' on this endpoint;
     # release-scoped queries use the default window (omit the param).
@@ -133,7 +129,7 @@ def event_summary(event: dict) -> dict:
     }
 
 
-def issue_detail(api: SentryAPI, short_id: str) -> dict | None:
+def issue_detail(api: SentryAPI, short_id: str, raw: bool = False) -> dict | None:
     # Sentry's project-issues search does not accept `shortId:` as a query
     # field. Fetch the bounded unresolved set and exact-match locally.
     issues = fetch_issues(api, "is:unresolved")
@@ -141,6 +137,12 @@ def issue_detail(api: SentryAPI, short_id: str) -> dict | None:
     if issue is None:
         return None
     event = latest_event(api, str(issue.get("id")))
+    if raw:
+        # Read-only escape hatch for hang triage: the summary drops thread
+        # state, contexts, tags and breadcrumbs, which is exactly what a hang
+        # investigation needs. Dumping the untouched event keeps triage on the
+        # tested client path instead of ad-hoc curl/inline-python.
+        return {"raw_event": event}
     return {"issue": issue_row(issue), "event": event_summary(event)}
 
 
@@ -169,9 +171,7 @@ def gate_verdict(rows: list[dict], release: str, watch: list[str]) -> dict:
     """Close-gate semantics: PASS only if the release HAS field events (adoption)
     AND no watched group fired on it AND no hang group's latest event is on it."""
     watched_fired = [r for r in rows if r["shortId"] in watch]
-    live_hangs = [
-        r for r in rows if is_hang(r) and r.get("latestEventRelease") == release
-    ]
+    live_hangs = [r for r in rows if is_hang(r) and r.get("latestEventRelease") == release]
     if not rows:
         verdict = "NO_ADOPTION"
     elif watched_fired or live_hangs:
@@ -193,11 +193,7 @@ def gate_verdict(rows: list[dict], release: str, watch: list[str]) -> dict:
 def format_rows(rows: list[dict]) -> str:
     lines = []
     for r in rows:
-        rel = (
-            f" | latest-release: {r['latestEventRelease']}"
-            if r.get("latestEventRelease")
-            else ""
-        )
+        rel = f" | latest-release: {r['latestEventRelease']}" if r.get("latestEventRelease") else ""
         lines.append(
             f"{r['shortId']:<16} | {r['culprit'] or r['title']:<50} "
             f"| count: {r['count']:>4} | {r['firstSeen']} -> {r['lastSeen']}{rel}"
@@ -228,15 +224,19 @@ def main(argv: list[str] | None = None, api: SentryAPI | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--release", help="list issues with events on this release")
     parser.add_argument("--issue", metavar="SHORT_ID", help="show latest event stack summary")
-    parser.add_argument(
-        "--gate", metavar="RELEASE", help="run close-gate verdict for a release"
-    )
+    parser.add_argument("--gate", metavar="RELEASE", help="run close-gate verdict for a release")
     parser.add_argument(
         "--watch",
         default="",
         help="comma-separated Sentry shortIds that must NOT fire on the gated release",
     )
     parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="with --issue: print the untouched latest-event JSON "
+        "(thread state, contexts, tags, breadcrumbs). Read-only.",
+    )
     args = parser.parse_args(argv)
 
     if api is None:
@@ -251,10 +251,13 @@ def main(argv: list[str] | None = None, api: SentryAPI | None = None) -> int:
 
     try:
         if args.issue:
-            detail = issue_detail(api, args.issue)
+            detail = issue_detail(api, args.issue, raw=args.raw)
             if detail is None:
                 print(f"ERROR: Sentry issue {args.issue} not found", file=sys.stderr)
                 return 1
+            if args.raw:
+                print(json.dumps(detail["raw_event"], indent=2))
+                return 0
             print(json.dumps(detail, indent=2) if args.as_json else format_issue_detail(detail))
             return 0
 

--- a/scripts/test-sentry-check.py
+++ b/scripts/test-sentry-check.py
@@ -97,18 +97,14 @@ class TestGateVerdict(unittest.TestCase):
         self.assertEqual(result["verdict"], "NO_ADOPTION")
 
     def test_watched_group_fired_fails(self):
-        api = FakeAPI(
-            issues=[_issue("APPLE-MACOS-33", iid="1")], latest_releases={"1": "1.7.0"}
-        )
+        api = FakeAPI(issues=[_issue("APPLE-MACOS-33", iid="1")], latest_releases={"1": "1.7.0"})
         rows = self._rows(api)
         result = self.m.gate_verdict(rows, "1.7.1", watch=["APPLE-MACOS-33"])
         self.assertEqual(result["verdict"], "FAIL")
         self.assertEqual(result["watched_fired"], ["APPLE-MACOS-33"])
 
     def test_live_hang_group_fails_even_if_unwatched(self):
-        api = FakeAPI(
-            issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"}
-        )
+        api = FakeAPI(issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"})
         rows = self._rows(api)
         result = self.m.gate_verdict(rows, "1.7.1", watch=[])
         self.assertEqual(result["verdict"], "FAIL")
@@ -116,9 +112,7 @@ class TestGateVerdict(unittest.TestCase):
 
     def test_non_hang_issue_with_old_latest_release_passes(self):
         api = FakeAPI(
-            issues=[
-                _issue("APPLE-MACOS-2", title="NSCocoaErrorDomain: Code: 260", iid="3")
-            ],
+            issues=[_issue("APPLE-MACOS-2", title="NSCocoaErrorDomain: Code: 260", iid="3")],
             latest_releases={"3": "1.5.0"},
         )
         rows = self._rows(api)
@@ -126,9 +120,7 @@ class TestGateVerdict(unittest.TestCase):
         self.assertEqual(result["verdict"], "PASS")
 
     def test_hang_with_older_latest_release_passes(self):
-        api = FakeAPI(
-            issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"}
-        )
+        api = FakeAPI(issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"})
         rows = self._rows(api)
         result = self.m.gate_verdict(rows, "1.7.1", watch=[])
         self.assertEqual(result["verdict"], "PASS")
@@ -139,18 +131,14 @@ class TestMainExitCodes(unittest.TestCase):
         self.m = _load("sentry_check")
 
     def test_gate_fail_exits_1(self):
-        api = FakeAPI(
-            issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"}
-        )
+        api = FakeAPI(issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"})
         with patch("sys.stdout", new=StringIO()) as out:
             rc = self.m.main(["--gate", "1.7.1"], api=api)
         self.assertEqual(rc, 1)
         self.assertIn("GATE FAIL", out.getvalue())
 
     def test_gate_pass_exits_0(self):
-        api = FakeAPI(
-            issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"}
-        )
+        api = FakeAPI(issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"})
         with patch("sys.stdout", new=StringIO()) as out:
             rc = self.m.main(["--gate", "1.7.1", "--watch", "APPLE-MACOS-33"], api=api)
         self.assertEqual(rc, 0)
@@ -225,6 +213,18 @@ class TestMainExitCodes(unittest.TestCase):
             "MarkdownLinter.countOccurrences",
         )
         self.assertEqual(api.calls[0][1]["query"], "is:unresolved")
+
+    def test_issue_detail_raw_dumps_untouched_event(self):
+        event = {
+            "eventID": "evt-raw",
+            "release": {"version": "1.7.2"},
+            "contexts": {"device": {"free_memory": 123}},
+        }
+        api = FakeAPI(issues=[_issue("APPLE-MACOS-4J", iid="77")], latest_events={"77": event})
+        with patch("sys.stdout", new=StringIO()) as out:
+            rc = self.m.main(["--issue", "APPLE-MACOS-4J", "--raw"], api=api)
+        self.assertEqual(rc, 0)
+        self.assertEqual(__import__("json").loads(out.getvalue()), event)
 
     def test_issue_detail_missing_short_id_exits_1(self):
         with patch("sys.stderr", new=StringIO()) as err:

--- a/scripts/test-sentry-check.py
+++ b/scripts/test-sentry-check.py
@@ -97,14 +97,18 @@ class TestGateVerdict(unittest.TestCase):
         self.assertEqual(result["verdict"], "NO_ADOPTION")
 
     def test_watched_group_fired_fails(self):
-        api = FakeAPI(issues=[_issue("APPLE-MACOS-33", iid="1")], latest_releases={"1": "1.7.0"})
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-33", iid="1")], latest_releases={"1": "1.7.0"}
+        )
         rows = self._rows(api)
         result = self.m.gate_verdict(rows, "1.7.1", watch=["APPLE-MACOS-33"])
         self.assertEqual(result["verdict"], "FAIL")
         self.assertEqual(result["watched_fired"], ["APPLE-MACOS-33"])
 
     def test_live_hang_group_fails_even_if_unwatched(self):
-        api = FakeAPI(issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"})
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"}
+        )
         rows = self._rows(api)
         result = self.m.gate_verdict(rows, "1.7.1", watch=[])
         self.assertEqual(result["verdict"], "FAIL")
@@ -112,7 +116,9 @@ class TestGateVerdict(unittest.TestCase):
 
     def test_non_hang_issue_with_old_latest_release_passes(self):
         api = FakeAPI(
-            issues=[_issue("APPLE-MACOS-2", title="NSCocoaErrorDomain: Code: 260", iid="3")],
+            issues=[
+                _issue("APPLE-MACOS-2", title="NSCocoaErrorDomain: Code: 260", iid="3")
+            ],
             latest_releases={"3": "1.5.0"},
         )
         rows = self._rows(api)
@@ -120,7 +126,9 @@ class TestGateVerdict(unittest.TestCase):
         self.assertEqual(result["verdict"], "PASS")
 
     def test_hang_with_older_latest_release_passes(self):
-        api = FakeAPI(issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"})
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"}
+        )
         rows = self._rows(api)
         result = self.m.gate_verdict(rows, "1.7.1", watch=[])
         self.assertEqual(result["verdict"], "PASS")
@@ -131,14 +139,18 @@ class TestMainExitCodes(unittest.TestCase):
         self.m = _load("sentry_check")
 
     def test_gate_fail_exits_1(self):
-        api = FakeAPI(issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"})
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-2Z", iid="2")], latest_releases={"2": "1.7.1"}
+        )
         with patch("sys.stdout", new=StringIO()) as out:
             rc = self.m.main(["--gate", "1.7.1"], api=api)
         self.assertEqual(rc, 1)
         self.assertIn("GATE FAIL", out.getvalue())
 
     def test_gate_pass_exits_0(self):
-        api = FakeAPI(issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"})
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-4", iid="4")], latest_releases={"4": "1.4.2"}
+        )
         with patch("sys.stdout", new=StringIO()) as out:
             rc = self.m.main(["--gate", "1.7.1", "--watch", "APPLE-MACOS-33"], api=api)
         self.assertEqual(rc, 0)
@@ -220,11 +232,26 @@ class TestMainExitCodes(unittest.TestCase):
             "release": {"version": "1.7.2"},
             "contexts": {"device": {"free_memory": 123}},
         }
-        api = FakeAPI(issues=[_issue("APPLE-MACOS-4J", iid="77")], latest_events={"77": event})
+        api = FakeAPI(
+            issues=[_issue("APPLE-MACOS-4J", iid="77")],
+            latest_events={"77": event},
+        )
         with patch("sys.stdout", new=StringIO()) as out:
             rc = self.m.main(["--issue", "APPLE-MACOS-4J", "--raw"], api=api)
         self.assertEqual(rc, 0)
         self.assertEqual(__import__("json").loads(out.getvalue()), event)
+
+    def test_raw_without_issue_is_a_usage_error(self):
+        # --raw is only meaningful for --issue; a typo'd invocation must fail
+        # loudly instead of silently printing ordinary listing/gate output.
+        for argv in (["--raw"], ["--gate", "1.7.2", "--raw"], ["--release", "1.7.2", "--raw"]):
+            with self.subTest(argv=argv):
+                with patch("sys.stdout", new=StringIO()):
+                    with patch("sys.stderr", new=StringIO()) as err:
+                        with self.assertRaises(SystemExit) as ctx:
+                            self.m.main(argv, api=FakeAPI())
+                self.assertEqual(ctx.exception.code, 2)
+                self.assertIn("--raw requires --issue", err.getvalue())
 
     def test_issue_detail_missing_short_id_exits_1(self):
         with patch("sys.stderr", new=StringIO()) as err:


### PR DESCRIPTION
## What

Adds `python3 scripts/sentry_check.py --issue SHORT_ID --raw`: a read-only dump of the
untouched latest-event JSON, fetched through the existing Keychain-authenticated
`SentryAPI` client.

## Why

Triaging the new 1.7.2 hang group `APPLE-MACOS-4J` needed thread state, the `contexts`
block (app/device memory, thermal state, OS build), tags, and breadcrumbs. The existing
`--issue` summary keeps only in-app frames and drops all four. Without a subcommand, the
alternative is an ad-hoc curl / inline-python script that duplicates the Keychain auth
path and has no tests.

No Sentry state is mutated (no resolve/ignore). Read-only.

> **`--raw` output is not redacted.** A Sentry macOS event can carry the reporter's IP
> address (`user.ip_address`), device name and model (`contexts.device`), tags, and
> absolute filesystem paths in breadcrumbs and stack frames. Read it in the terminal;
> never paste it into a tracked file, an issue, or a PR body. This repository is public.
> The default `--issue` summary keeps only normalized in-app frames and carries none of
> that. Stated in the script docstring, the `--raw` help text, and
> `docs/research/markview-hang-triage-2026-08-12.md`.

## Triage result (no app code changed here)

`APPLE-MACOS-4J` is root-caused. The sampled main-thread stack is a synchronous cmark
render on the MainActor:

```
closure in PreviewViewModel.loadContent   PreviewViewModel.swift:226
PreviewViewModel.finishLoadContent        PreviewViewModel.swift:242
PreviewViewModel.renderImmediate          PreviewViewModel.swift:255
MarkdownRenderer.renderHTML               MarkdownRenderer.swift:30
cmark_render_html_with_mem -> escape_html -> cmark_strbuf_grow -> xrealloc
```

Line numbers map exactly to this tree at v1.7.2. It is the third member of the
mar-037 (file read off main) / #69 (lint off main) family: each fix moved one piece of
the load path off the main actor and left `renderImmediate` behind.

Reproduced: a dense-escapable-character document (9.7 MB in, 43 MB out) renders in
2.46 s and a large GFM table in 2.25 s in a release build, both past the 2000 ms ANR
threshold. `CMARK_OPT_SOURCEPOS` is a ~9x output amplifier on node-dense documents.

Rejected: memory pressure (61 MB RSS, 5.5 GB free), a #69 regression (lint is detached
and absent from the stack; `runLint` is called *after* the hung frame), WebKit, and
swift-markdown.

The fix (move the render off the main actor behind a generation guard) is **not** in
this PR: `finishLoadContent` sets `isLoaded = true` immediately after
`renderImmediate`, so making the render async requires choosing a new loading-state
contract, which is a product decision rather than a refactor.

A sanitized record of all of the above now lives in `docs/STATUS.md` so the root cause
survives this PR in tracked form. The full write-up (breadcrumb timeline, hypothesis
ranking, reproduction corpus) stays in `docs/personal/hang-4j-triage-2026-09-07.md`,
gitignored, because it quotes unredacted field data.

## Review round 2 (commits `dc3fc87`, `1400988`)

Five findings from the review; all five addressed.

1. **(major) Tracked doc asserted the opposite of the code.**
   `docs/research/markview-hang-triage-2026-08-12.md` said the `--issue` path
   "deliberately avoids printing the raw event payload" - a privacy property on a
   public repo, now false. That section is amended to scope the original claim to the
   summary path, record `--raw` as an opt-in dump, and spell out what the dump can
   contain. The same caution is in the `sentry_check.py` docstring and in the `--raw`
   help text.
2. **(minor) No tracked record of the root cause.** Added the `APPLE-MACOS-4J`
   subsection to `docs/STATUS.md` and two `Internal:` rows to `CHANGELOG.md` under a
   new `Unreleased` section (v1.7.2 is already tagged, so its notes are not rewritten).
3. **(minor) `--raw` silently ignored without `--issue`.** `main()` now calls
   `parser.error("--raw requires --issue SHORT_ID")`, exit code 2. Regression test
   written first and confirmed red ("SystemExit not raised") on all three bad
   invocations - `--raw`, `--gate 1.7.2 --raw`, `--release 1.7.2 --raw`.
4. **(minor) `--help` omitted the flag.** Added the missing line to the docstring Usage
   block, which is argparse's description.
5. **(minor) Two thirds of the diff was unrelated reflow.** That was the editor's
   format-on-write hook re-wrapping untouched lines to ~100 columns; the repo has no
   ruff/black config and no Python lint gate, so none of it was enforced. All eleven
   reflowed regions are restored. The diff is now the feature only: 32 added lines in
   `sentry_check.py`, 27 in the test file, zero reformatting.

Also corrected in this description: the new test asserts **parsed-JSON equality**, not
byte equality as previously claimed.

Not changed, and called out as a known limitation rather than fixed here: `--issue`
resolves short IDs only within the unbounded-page `is:unresolved` 14d fetch
(`sentry_check.py:135`), so a muted, resolved, or beyond-page-1 group reports "not
found" with rc 1. That is pre-existing and untouched by this PR, but it is the
reliability floor under the new triage path and deserves its own change.

## Test plan

- `test_issue_detail_raw_dumps_untouched_event` asserts the printed JSON parses back
  equal to the event the API returned, including the `contexts` block the summary path
  drops.
- `test_raw_without_issue_is_a_usage_error` asserts `SystemExit` with code 2 and the
  usage message for all three `--raw`-without-`--issue` invocations.
- `python3 scripts/test-sentry-check.py` -> 16 tests, OK.
- `python3 scripts/verify.py` -> `=== All checks passed ===` (368 Swift tests passed,
  0 failed; PDF 4 passed; golden baselines clean; all 9 script suites passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
