### PR TITLE
mar-047+048: require Verify CI check; bundle.py Dock guard + dev-cleanup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Internal: `scripts/sentry_check.py --issue SHORT_ID --raw` prints the untouched latest event JSON through the existing Keychain-authenticated read-only client, so hang triage that needs thread state, `contexts`, tags, or breadcrumbs stays on the tested path instead of an ad-hoc curl script (mar-043 follow-up). The dump is not redacted; see the script docstring before sharing it.
 - Internal: record the root cause of the v1.7.2 `APPLE-MACOS-4J` main-thread render hang in `docs/STATUS.md`. Reproduced and root-caused, fix deferred to its own PR.
+- Internal: make the Verify CI job a required status check on `main` so a red Verify can no longer auto-merge (mar-047, #75).
+- Internal: `bundle.py --install` refuses (unless `--force`) when a Dock tile is pinned to a `build/` output path or the repo-root `MarkView.app` - both are ephemeral dev output deleted by the new `scripts/dev_cleanup.py`, which reclaims `build/`, `MarkView.app`, and stale Xcode DerivedData for this project in one dry-run-by-default step (mar-048, #75).
 
 ## v1.7.2
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ python3 scripts/test-github-parity-check.py  # github_parity_check.py tests (13 
 python3 scripts/test-ci-status.py     # ci_status.py tests (24 tests, no live gh CLI)
 python3 scripts/test-sentry-check.py  # sentry_check.py tests (14 tests, no live Sentry API/Keychain)
 python3 scripts/test-bundle.py        # bundle.py tests, incl. mar-048 Dock-tile guard (no real xcodebuild/codesign/Dock)
-python3 scripts/test-dev-cleanup.py   # dev-cleanup.py tests (mar-048; real tempdirs, never the actual repo or ~/Library)
+python3 scripts/test-dev-cleanup.py   # dev_cleanup.py tests (mar-048; real tempdirs, never the actual repo or ~/Library)
 make playwright                       # Playwright e2e DOM tests (66 tests) — rebuilds MarkViewHTMLGen, runs Chromium
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ python3 scripts/test-post-launch.py   # post_launch.py tests (10 tests, never op
 python3 scripts/test-github-parity-check.py  # github_parity_check.py tests (13 tests, no live GitHub API/swift build)
 python3 scripts/test-ci-status.py     # ci_status.py tests (24 tests, no live gh CLI)
 python3 scripts/test-sentry-check.py  # sentry_check.py tests (14 tests, no live Sentry API/Keychain)
+python3 scripts/test-bundle.py        # bundle.py tests, incl. mar-048 Dock-tile guard (no real xcodebuild/codesign/Dock)
+python3 scripts/test-dev-cleanup.py   # dev-cleanup.py tests (mar-048; real tempdirs, never the actual repo or ~/Library)
 make playwright                       # Playwright e2e DOM tests (66 tests) — rebuilds MarkViewHTMLGen, runs Chromium
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ swift build -c release
 bash scripts/bundle.sh --install
 ```
 
-Creates `MarkView.app` in `/Applications` and registers it with Launch Services for right-click > Open With in Finder.
+Creates `MarkView.app` in `/Applications` and registers it with Launch Services for right-click > Open With in Finder. Refuses (unless you pass `--force`) if a Dock tile is pinned to a `build/` or repo-root `MarkView.app` path, since both are ephemeral dev output.
 
 ### Install CLI
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -355,7 +355,9 @@ swift build                        # Debug build (all targets)
 swift build -c release             # Release build
 bash scripts/bundle.sh             # Create MarkView.app bundle
 bash scripts/bundle.sh --install   # Bundle + install to /Applications
+bash scripts/bundle.sh --install --force  # ...skip the Dock-tile ephemeral-output guard
 bash scripts/install-cli.sh        # Install mdpreview CLI to ~/.local/bin/
+python3 scripts/dev_cleanup.py [--apply]  # Reclaim build/, MarkView.app, DerivedData
 ```
 
 ### Bundle Structure

--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -3,8 +3,8 @@
 bundle.py — Build .app bundle using xcodebuild (XcodeGen project).
 
 Usage:
-    python3 scripts/bundle.py [--install] [--notarize]
-    bash scripts/bundle.sh [--install] [--notarize]   (thin exec wrapper)
+    python3 scripts/bundle.py [--install] [--notarize] [--force]
+    bash scripts/bundle.sh [--install] [--notarize] [--force]   (thin exec wrapper)
 
 Prerequisites: brew install xcodegen && xcodegen generate
 
@@ -17,16 +17,24 @@ those fixtures, and the mar-026 log-to-file fix (surface xcodebuild/
 swift-build root causes instead of a masked `| tail -5` pipe) that this
 port preserves.
 
+mar-048: `--install` refuses (unless `--force`) when a Dock tile is pinned
+to a `build/` output path — that tree is ephemeral (xcodebuild output,
+deleted by dev-cleanup.py), so a Dock tile pointing into it silently
+breaks. The check is read-only (`defaults export`, never `defaults
+write`) — it never mutates the Dock.
+
 Every external command runs through `_run()` so tests can stub the
 subprocess boundary without invoking a real xcodebuild/swift/codesign.
 """
 
 from __future__ import annotations
 
+import plistlib
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent
 
@@ -148,22 +156,95 @@ def _find_frameworks_signables(directory: Path) -> list[Path]:
 # ── Argument parsing ────────────────────────────────────────────────────────
 
 
-def parse_args(argv: list[str]) -> tuple[bool, bool]:
-    """Returns (do_install, do_notarize). Raises BundleError on an unknown
-    option, matching bash's `Unknown option: X` + usage + exit 1."""
+def parse_args(argv: list[str]) -> tuple[bool, bool, bool]:
+    """Returns (do_install, do_notarize, do_force). Raises BundleError on an
+    unknown option, matching bash's `Unknown option: X` + usage + exit 1."""
     do_install = False
     do_notarize = False
+    do_force = False
     for arg in argv:
         if arg == "--install":
             do_install = True
         elif arg == "--notarize":
             do_notarize = True
+        elif arg == "--force":
+            do_force = True
         else:
             raise BundleError(
                 f"Unknown option: {arg}\n"
-                "Usage: bash scripts/bundle.sh [--install] [--notarize]"
+                "Usage: bash scripts/bundle.sh [--install] [--notarize] [--force]"
             )
-    return do_install, do_notarize
+    return do_install, do_notarize, do_force
+
+
+# ── Dock tile safety (mar-048) ──────────────────────────────────────────────
+
+
+def _decode_dock_file_url(url: str) -> Path | None:
+    """Decode a Dock tile's `file://` URL (mirrors
+    `tile-data.file-data._CFURLString`) into a filesystem path."""
+    if not url or not url.startswith("file://"):
+        return None
+    return Path(unquote(urlparse(url).path))
+
+
+def read_dock_persistent_apps(out=print) -> list[dict]:
+    """Read Dock app tiles via `defaults export com.apple.dock -`. Read-only —
+    never calls `defaults write` or otherwise mutates the Dock. Returns []
+    (never raises) if the export fails or doesn't parse, so callers degrade
+    to "nothing to warn about" rather than aborting the whole bundle build."""
+    rc, stdout, _ = _run(["defaults", "export", "com.apple.dock", "-"])
+    if rc != 0 or not stdout:
+        return []
+    try:
+        data = plistlib.loads(stdout.encode("utf-8"))
+    except (ValueError, plistlib.InvalidFileException):
+        return []
+    apps = data.get("persistent-apps", [])
+    return apps if isinstance(apps, list) else []
+
+
+def find_dock_tiles_pointing_at_build(project_dir: Path, out=print) -> list[str]:
+    """Return the file:// paths (decoded) of any pinned Dock tile that lives
+    inside `project_dir/build/` — the ephemeral xcodebuild output tree that
+    dev-cleanup.py deletes. A Dock tile pinned there breaks (shows a generic
+    icon) once that tree is cleaned; the installed app under /Applications
+    is the stable target."""
+    build_root = (project_dir / "build").resolve()
+    hits: list[str] = []
+    for tile in read_dock_persistent_apps(out):
+        file_data = tile.get("tile-data", {}).get("file-data", {})
+        url = file_data.get("_CFURLString")
+        path = _decode_dock_file_url(url) if isinstance(url, str) else None
+        if path is None:
+            continue
+        resolved = path.resolve()
+        if resolved == build_root or build_root in resolved.parents:
+            hits.append(str(path))
+    return hits
+
+
+def check_dock_not_pointing_at_build(
+    project_dir: Path, force: bool, out=print
+) -> None:
+    """`--install` guard: refuse (unless `--force`) when a Dock tile is
+    pinned to a `build/` output path. Read-only — never mutates the Dock."""
+    hits = find_dock_tiles_pointing_at_build(project_dir, out)
+    if not hits:
+        return
+    if force:
+        out("⚠ Dock tile(s) pinned to a build/ output path (continuing: --force):")
+        for hit in hits:
+            out(f"  {hit}")
+        return
+    lines = [
+        "ERROR: Dock has a tile pinned to a build/ output path — it will break "
+        "(show a generic icon) once build/ is cleaned:",
+        *(f"  {hit}" for hit in hits),
+        f"Re-pin the Dock tile to the installed app (/Applications/{APP_NAME}.app), "
+        "or pass --force to skip this check.",
+    ]
+    raise BundleError("\n".join(lines))
 
 
 # ── Signing identity ────────────────────────────────────────────────────────
@@ -598,7 +679,10 @@ def run_bundle(
     install_dir: Path | None = None,
     out=print,
 ) -> int:
-    do_install, do_notarize = parse_args(argv)
+    do_install, do_notarize, do_force = parse_args(argv)
+
+    if do_install:
+        check_dock_not_pointing_at_build(project_dir, do_force, out)
 
     app_dir = project_dir / f"{APP_NAME}.app"
     if install_dir is None:

--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -18,10 +18,12 @@ swift-build root causes instead of a masked `| tail -5` pipe) that this
 port preserves.
 
 mar-048: `--install` refuses (unless `--force`) when a Dock tile is pinned
-to a `build/` output path — that tree is ephemeral (xcodebuild output,
-deleted by dev-cleanup.py), so a Dock tile pointing into it silently
-breaks. The check is read-only (`defaults export`, never `defaults
-write`) — it never mutates the Dock.
+to an ephemeral output path (the `build/` tree or the repo-root
+`MarkView.app` — both deleted by dev_cleanup.py), so a Dock tile pointing
+into either silently breaks. The check is read-only (`defaults export`,
+never `defaults write`) — it never mutates the Dock. The matched roots
+come from dev_cleanup.static_targets() so the two scripts cannot drift
+out of sync about what counts as ephemeral.
 
 Every external command runs through `_run()` so tests can stub the
 subprocess boundary without invoking a real xcodebuild/swift/codesign.
@@ -35,6 +37,9 @@ import subprocess
 import sys
 from pathlib import Path
 from urllib.parse import unquote, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from dev_cleanup import static_targets  # noqa: E402
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent
 
@@ -145,9 +150,7 @@ def _find_frameworks_signables(directory: Path) -> list[Path]:
         return []
     matches = []
     for p in sorted(directory.rglob("*")):
-        is_exec_dylib = (
-            p.is_file() and p.name.endswith(".dylib") and (p.stat().st_mode & 0o111)
-        )
+        is_exec_dylib = p.is_file() and p.name.endswith(".dylib") and (p.stat().st_mode & 0o111)
         if is_exec_dylib or p.name == "Sentry":
             matches.append(p)
     return matches
@@ -188,7 +191,7 @@ def _decode_dock_file_url(url: str) -> Path | None:
     return Path(unquote(urlparse(url).path))
 
 
-def read_dock_persistent_apps(out=print) -> list[dict]:
+def read_dock_persistent_apps() -> list[dict]:
     """Read Dock app tiles via `defaults export com.apple.dock -`. Read-only —
     never calls `defaults write` or otherwise mutates the Dock. Returns []
     (never raises) if the export fails or doesn't parse, so callers degrade
@@ -204,42 +207,42 @@ def read_dock_persistent_apps(out=print) -> list[dict]:
     return apps if isinstance(apps, list) else []
 
 
-def find_dock_tiles_pointing_at_build(project_dir: Path, out=print) -> list[str]:
+def find_dock_tiles_pointing_at_ephemeral_output(project_dir: Path) -> list[str]:
     """Return the file:// paths (decoded) of any pinned Dock tile that lives
-    inside `project_dir/build/` — the ephemeral xcodebuild output tree that
-    dev-cleanup.py deletes. A Dock tile pinned there breaks (shows a generic
-    icon) once that tree is cleaned; the installed app under /Applications
-    is the stable target."""
-    build_root = (project_dir / "build").resolve()
+    inside one of dev_cleanup.static_targets(project_dir) — the `build/`
+    xcodebuild output tree and the repo-root `MarkView.app`, both ephemeral
+    outputs that dev_cleanup.py deletes. A Dock tile pinned to either breaks
+    (shows a generic icon) once cleaned; the installed app under
+    /Applications is the stable target."""
+    roots = [root.resolve() for root in static_targets(project_dir)]
     hits: list[str] = []
-    for tile in read_dock_persistent_apps(out):
+    for tile in read_dock_persistent_apps():
         file_data = tile.get("tile-data", {}).get("file-data", {})
         url = file_data.get("_CFURLString")
         path = _decode_dock_file_url(url) if isinstance(url, str) else None
         if path is None:
             continue
         resolved = path.resolve()
-        if resolved == build_root or build_root in resolved.parents:
+        if any(resolved == root or root in resolved.parents for root in roots):
             hits.append(str(path))
     return hits
 
 
-def check_dock_not_pointing_at_build(
-    project_dir: Path, force: bool, out=print
-) -> None:
+def check_dock_not_pointing_at_ephemeral_output(project_dir: Path, force: bool, out=print) -> None:
     """`--install` guard: refuse (unless `--force`) when a Dock tile is
-    pinned to a `build/` output path. Read-only — never mutates the Dock."""
-    hits = find_dock_tiles_pointing_at_build(project_dir, out)
+    pinned to an ephemeral output path (`build/` or the repo-root
+    `MarkView.app`). Read-only — never mutates the Dock."""
+    hits = find_dock_tiles_pointing_at_ephemeral_output(project_dir)
     if not hits:
         return
     if force:
-        out("⚠ Dock tile(s) pinned to a build/ output path (continuing: --force):")
+        out("⚠ Dock tile(s) pinned to an ephemeral output path (continuing: --force):")
         for hit in hits:
             out(f"  {hit}")
         return
     lines = [
-        "ERROR: Dock has a tile pinned to a build/ output path — it will break "
-        "(show a generic icon) once build/ is cleaned:",
+        "ERROR: Dock has a tile pinned to an ephemeral output path (build/ or "
+        f"{APP_NAME}.app) — it will break (show a generic icon) once cleaned:",
         *(f"  {hit}" for hit in hits),
         f"Re-pin the Dock tile to the installed app (/Applications/{APP_NAME}.app), "
         "or pass --force to skip this check.",
@@ -265,9 +268,7 @@ def detect_signing_identity(out=print) -> tuple[str, list[str]]:
 
 
 def read_version(plist: Path) -> str:
-    rc, stdout, _ = _run(
-        ["plutil", "-extract", "CFBundleShortVersionString", "raw", str(plist)]
-    )
+    rc, stdout, _ = _run(["plutil", "-extract", "CFBundleShortVersionString", "raw", str(plist)])
     return stdout.strip() if rc == 0 else "unknown"
 
 
@@ -279,9 +280,7 @@ def bump_build_number(project_dir: Path) -> str:
     git_build = stdout.strip() if rc == 0 else "0"
 
     plist = project_dir / "Sources/MarkView/Info.plist"
-    _run_or_abort(
-        ["plutil", "-replace", "CFBundleVersion", "-string", git_build, str(plist)]
-    )
+    _run_or_abort(["plutil", "-replace", "CFBundleVersion", "-string", git_build, str(plist)])
 
     ql_plist = project_dir / "Sources/MarkViewQuickLook/Info.plist"
     if ql_plist.is_file():
@@ -307,9 +306,7 @@ def xcodegen_generate(project_dir: Path, out=print) -> None:
     (e.g. mermaid.min.js) from the build."""
     out("--- Generating Xcode project ---")
     if not _which("xcodegen"):
-        raise BundleError(
-            "ERROR: xcodegen not found. Install with: brew install xcodegen"
-        )
+        raise BundleError("ERROR: xcodegen not found. Install with: brew install xcodegen")
     _run_or_abort(
         [
             "xcodegen",
@@ -453,9 +450,7 @@ def _codesign_cmd(
     ]
 
 
-def _resign(
-    sign_identity: str, sign_flags: list[str], target: Path, label: str, out=print
-) -> None:
+def _resign(sign_identity: str, sign_flags: list[str], target: Path, label: str, out=print) -> None:
     """Non-fatal re-sign (bash: `codesign ... 2>/dev/null && echo ok || true`)."""
     rc, _, _ = _run(_codesign_cmd(sign_identity, sign_flags, [], target))
     if rc == 0:
@@ -494,9 +489,7 @@ def resign_nested_code(
     # Gatekeeper rejects "Developer ID outer + ad-hoc inner main executable".
     main_bin = app_dir / "Contents/MacOS" / APP_NAME
     if main_bin.is_file():
-        _resign(
-            sign_identity, sign_flags, main_bin, f"{APP_NAME} (main executable)", out
-        )
+        _resign(sign_identity, sign_flags, main_bin, f"{APP_NAME} (main executable)", out)
 
     # Re-sign Quick Look extension with entitlements + timestamp.
     ql_appex = app_dir / "Contents/PlugIns" / f"{QL_NAME}.appex"
@@ -509,13 +502,9 @@ def resign_nested_code(
             out(f"  ✓ Generated PkgInfo for {QL_NAME}.appex")
 
         entitlements_flags = (
-            ["--entitlements", str(entitlements_ql)]
-            if entitlements_ql.is_file()
-            else []
+            ["--entitlements", str(entitlements_ql)] if entitlements_ql.is_file() else []
         )
-        rc, _, _ = _run(
-            _codesign_cmd(sign_identity, sign_flags, entitlements_flags, ql_appex)
-        )
+        rc, _, _ = _run(_codesign_cmd(sign_identity, sign_flags, entitlements_flags, ql_appex))
         if rc == 0:
             out(f"  ✓ Re-signed: {QL_NAME}.appex")
 
@@ -533,9 +522,7 @@ def resign_outer_bundle(
     entitlements_flags = (
         ["--entitlements", str(entitlements_app)] if entitlements_app.is_file() else []
     )
-    rc, _, _ = _run(
-        _codesign_cmd(sign_identity, sign_flags, entitlements_flags, app_dir)
-    )
+    rc, _, _ = _run(_codesign_cmd(sign_identity, sign_flags, entitlements_flags, app_dir))
     if rc == 0:
         out("✓ App bundle re-signed")
     else:
@@ -584,9 +571,7 @@ def verify_bundle_structure(app_dir: Path, sign_identity: str, out=print) -> boo
         "Missing document types",
     )
 
-    ql_appex_exe = (
-        app_dir / "Contents/PlugIns" / f"{QL_NAME}.appex/Contents/MacOS" / QL_NAME
-    )
+    ql_appex_exe = app_dir / "Contents/PlugIns" / f"{QL_NAME}.appex/Contents/MacOS" / QL_NAME
     if ql_appex_exe.is_file():
         out("  ✓ Quick Look extension exists")
     else:
@@ -599,9 +584,7 @@ def verify_bundle_structure(app_dir: Path, sign_identity: str, out=print) -> boo
     elif sign_identity == "-":
         out("  ⚠ Ad-hoc signature (expected — no Developer ID cert found)")
     else:
-        out(
-            "  ✗ Code signature invalid with Developer ID — bundle will be rejected by Gatekeeper"
-        )
+        out("  ✗ Code signature invalid with Developer ID — bundle will be rejected by Gatekeeper")
         valid = False
 
     out("")
@@ -627,11 +610,7 @@ def install_bundle(app_dir: Path, install_dir: Path, out=print) -> None:
     if LSREGISTER.is_file():
         rc, stdout, _ = _run(["mdfind", f"kMDItemCFBundleIdentifier == '{BUNDLE_ID}'"])
         for stale_path in stdout.splitlines() if rc == 0 else []:
-            if (
-                stale_path
-                and stale_path != str(install_dir)
-                and Path(stale_path).is_dir()
-            ):
+            if stale_path and stale_path != str(install_dir) and Path(stale_path).is_dir():
                 _run([str(LSREGISTER), "-u", stale_path])
                 out(f"✓ Unregistered stale copy: {stale_path}")
 
@@ -682,15 +661,13 @@ def run_bundle(
     do_install, do_notarize, do_force = parse_args(argv)
 
     if do_install:
-        check_dock_not_pointing_at_build(project_dir, do_force, out)
+        check_dock_not_pointing_at_ephemeral_output(project_dir, do_force, out)
 
     app_dir = project_dir / f"{APP_NAME}.app"
     if install_dir is None:
         install_dir = Path(f"/Applications/{APP_NAME}.app")
     entitlements_app = project_dir / "Sources/MarkView/MarkView.entitlements"
-    entitlements_ql = (
-        project_dir / "Sources/MarkViewQuickLook/MarkViewQuickLook.entitlements"
-    )
+    entitlements_ql = project_dir / "Sources/MarkViewQuickLook/MarkViewQuickLook.entitlements"
 
     sign_identity, sign_flags = detect_signing_identity(out)
     if do_notarize and sign_identity == "-":

--- a/scripts/dev-cleanup.py
+++ b/scripts/dev-cleanup.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+dev-cleanup.py — Reclaim local dev-build disk space for MarkView (mar-048).
+
+Removes three classes of ephemeral build output that accumulate across dev
+iterations and are never the record source (the record source is /Applications,
+installed by scripts/bundle.py --install):
+
+  - <repo>/build/                                     (xcodebuild -derivedDataPath
+                                                         output; scripts/bundle.py)
+  - <repo>/MarkView.app                                (repo-root bundle produced
+                                                         by scripts/bundle.py)
+  - ~/Library/Developer/Xcode/DerivedData/MarkView-*   (Xcode.app GUI DerivedData
+                                                         for this project)
+
+Dry-run by default: lists every target with its size and deletes nothing.
+Pass --apply to actually delete. Every path is printed with its size before
+deletion in both modes, so a dry run tells you exactly what --apply will do.
+
+Usage:
+    python3 scripts/dev-cleanup.py            # dry run (default)
+    python3 scripts/dev-cleanup.py --apply     # actually delete
+
+No subprocess calls — pure filesystem walk/delete, so tests exercise real
+temp directories (project_dir/home are injectable) rather than stubbing a
+command boundary.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent
+APP_NAME = "MarkView"
+
+
+class CleanupError(Exception):
+    """Raised to abort before any filesystem work. `code` is the process
+    exit code to use."""
+
+    def __init__(self, message: str, code: int = 1) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+
+def parse_args(argv: list[str]) -> bool:
+    """Returns do_apply. Raises CleanupError on an unknown option."""
+    do_apply = False
+    for arg in argv:
+        if arg == "--apply":
+            do_apply = True
+        else:
+            raise CleanupError(
+                f"Unknown option: {arg}\nUsage: python3 scripts/dev-cleanup.py [--apply]"
+            )
+    return do_apply
+
+
+# ── Size helpers ─────────────────────────────────────────────────────────────
+
+
+def human_size(num_bytes: int) -> str:
+    """Format bytes as e.g. `1.2 GB` (binary/1024 units, whole bytes have no
+    decimal — mirrors macOS Finder-style sizing closely enough for a CLI
+    report, not byte-exact `du -h`)."""
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    value = float(num_bytes)
+    for unit in ("KB", "MB", "GB"):
+        value /= 1024
+        if value < 1024:
+            return f"{value:.1f} {unit}"
+    return f"{value:.1f} TB"
+
+
+def _dir_size(path: Path) -> int:
+    """Recursive size in bytes. Does not follow directory symlinks (mirrors
+    `du` without `-L`) to avoid double-counting or infinite loops through a
+    symlinked tree; a symlink itself is counted at its own (tiny) size."""
+    try:
+        if path.is_symlink():
+            return path.lstat().st_size
+        if path.is_file():
+            return path.stat().st_size
+        if not path.is_dir():
+            return 0
+    except OSError:
+        return 0
+    total = 0
+    try:
+        children = list(path.iterdir())
+    except OSError:
+        return 0
+    for child in children:
+        total += _dir_size(child)
+    return total
+
+
+def _remove(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+# ── Targets ──────────────────────────────────────────────────────────────────
+
+
+def find_targets(project_dir: Path, home: Path) -> list[Path]:
+    """Existing cleanup targets for this project: the repo-local build/
+    output, the repo-root .app bundle, and any DerivedData products under
+    Xcode's global cache for this project. Only paths that currently exist
+    are returned, in a stable (build, app, DerivedData...) order."""
+    targets = [project_dir / "build", project_dir / f"{APP_NAME}.app"]
+    derived_data = home / "Library/Developer/Xcode/DerivedData"
+    if derived_data.is_dir():
+        targets.extend(sorted(derived_data.glob(f"{APP_NAME}-*")))
+    return [t for t in targets if t.is_symlink() or t.exists()]
+
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+
+
+def run_cleanup(
+    argv: list[str],
+    project_dir: Path = PROJECT_DIR,
+    home: Path | None = None,
+    out=print,
+) -> int:
+    do_apply = parse_args(argv)
+    if home is None:
+        home = Path.home()
+
+    targets = find_targets(project_dir, home)
+    if not targets:
+        out("Nothing to clean — no build/, MarkView.app, or DerivedData products found.")
+        return 0
+
+    sizes = [(t, _dir_size(t)) for t in targets]
+    total = sum(size for _, size in sizes)
+
+    if do_apply:
+        out("=== Dev cleanup (deleting) ===")
+        for target, size in sizes:
+            _remove(target)
+            out(f"  ✓ Removed {target} ({human_size(size)})")
+        out("")
+        out(f"✓ Freed {human_size(total)} ({len(sizes)} items)")
+    else:
+        out("=== Dev cleanup (dry run) ===")
+        for target, size in sizes:
+            out(f"  {target}  {human_size(size)}")
+        out("")
+        out(f"Total: {len(sizes)} items, {human_size(total)}")
+        out("Dry run only — nothing deleted. Re-run with --apply to delete.")
+
+    return 0
+
+
+def main() -> None:
+    try:
+        sys.exit(run_cleanup(sys.argv[1:]))
+    except CleanupError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(exc.code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev_cleanup.py
+++ b/scripts/dev_cleanup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-dev-cleanup.py — Reclaim local dev-build disk space for MarkView (mar-048).
+dev_cleanup.py — Reclaim local dev-build disk space for MarkView (mar-048).
 
 Removes three classes of ephemeral build output that accumulate across dev
 iterations and are never the record source (the record source is /Applications,
@@ -13,13 +13,18 @@ installed by scripts/bundle.py --install):
   - ~/Library/Developer/Xcode/DerivedData/MarkView-*   (Xcode.app GUI DerivedData
                                                          for this project)
 
+`static_targets()` is the single source of truth for the first two (the
+project-relative, always-known-location roots) — scripts/bundle.py imports
+it so its Dock-tile guard can never drift out of sync with what this script
+actually deletes.
+
 Dry-run by default: lists every target with its size and deletes nothing.
 Pass --apply to actually delete. Every path is printed with its size before
 deletion in both modes, so a dry run tells you exactly what --apply will do.
 
 Usage:
-    python3 scripts/dev-cleanup.py            # dry run (default)
-    python3 scripts/dev-cleanup.py --apply     # actually delete
+    python3 scripts/dev_cleanup.py            # dry run (default)
+    python3 scripts/dev_cleanup.py --apply     # actually delete
 
 No subprocess calls — pure filesystem walk/delete, so tests exercise real
 temp directories (project_dir/home are injectable) rather than stubbing a
@@ -56,7 +61,7 @@ def parse_args(argv: list[str]) -> bool:
             do_apply = True
         else:
             raise CleanupError(
-                f"Unknown option: {arg}\nUsage: python3 scripts/dev-cleanup.py [--apply]"
+                f"Unknown option: {arg}\nUsage: python3 scripts/dev_cleanup.py [--apply]"
             )
     return do_apply
 
@@ -75,6 +80,7 @@ def human_size(num_bytes: int) -> str:
         value /= 1024
         if value < 1024:
             return f"{value:.1f} {unit}"
+    value /= 1024
     return f"{value:.1f} TB"
 
 
@@ -111,12 +117,22 @@ def _remove(path: Path) -> None:
 # ── Targets ──────────────────────────────────────────────────────────────────
 
 
+def static_targets(project_dir: Path) -> list[Path]:
+    """The two ephemeral-output roots whose location is knowable from
+    `project_dir` alone (no home-directory glob needed): the xcodebuild
+    `build/` output and the repo-root `.app` bundle. Returned unconditionally
+    (not filtered by existence) — this is also the root list
+    scripts/bundle.py's Dock-tile guard matches against, so a Dock tile
+    pinned to either path is caught even before the first cleanup run."""
+    return [project_dir / "build", project_dir / f"{APP_NAME}.app"]
+
+
 def find_targets(project_dir: Path, home: Path) -> list[Path]:
     """Existing cleanup targets for this project: the repo-local build/
     output, the repo-root .app bundle, and any DerivedData products under
     Xcode's global cache for this project. Only paths that currently exist
     are returned, in a stable (build, app, DerivedData...) order."""
-    targets = [project_dir / "build", project_dir / f"{APP_NAME}.app"]
+    targets = list(static_targets(project_dir))
     derived_data = home / "Library/Developer/Xcode/DerivedData"
     if derived_data.is_dir():
         targets.extend(sorted(derived_data.glob(f"{APP_NAME}-*")))

--- a/scripts/test-bundle.py
+++ b/scripts/test-bundle.py
@@ -64,13 +64,21 @@ AD_HOC_IDENTITY_OUTPUT = "     0 valid identities found\n"
 class TestHelpers(unittest.TestCase):
     def test_parse_args_defaults(self):
         mod = _load("bundle")
-        self.assertEqual(mod.parse_args([]), (False, False))
+        self.assertEqual(mod.parse_args([]), (False, False, False))
 
     def test_parse_args_install_and_notarize(self):
         mod = _load("bundle")
-        self.assertEqual(mod.parse_args(["--install"]), (True, False))
-        self.assertEqual(mod.parse_args(["--notarize"]), (False, True))
-        self.assertEqual(mod.parse_args(["--install", "--notarize"]), (True, True))
+        self.assertEqual(mod.parse_args(["--install"]), (True, False, False))
+        self.assertEqual(mod.parse_args(["--notarize"]), (False, True, False))
+        self.assertEqual(
+            mod.parse_args(["--install", "--notarize"]), (True, True, False)
+        )
+
+    def test_parse_args_force(self):
+        mod = _load("bundle")
+        self.assertEqual(
+            mod.parse_args(["--install", "--force"]), (True, False, True)
+        )
 
     def test_parse_args_unknown_option_raises(self):
         mod = _load("bundle")
@@ -157,6 +165,141 @@ class TestHelpers(unittest.TestCase):
             (sentry_dir / "Sentry").write_text("not executable, not a dylib")
             found = mod._find_frameworks_signables(tmp)
         self.assertIn(sentry_dir / "Sentry", found)
+
+
+# ── Dock tile safety (mar-048) ──────────────────────────────────────────────
+
+
+def _dock_export_xml(tile_urls: list[str]) -> str:
+    """Build a fake `defaults export com.apple.dock -` XML payload with one
+    persistent-apps file-tile per URL (mirrors the real tile-data shape)."""
+    apps = [
+        {
+            "tile-data": {
+                "file-data": {"_CFURLString": url, "_CFURLStringType": 15},
+                "file-label": f"App{i}",
+            },
+            "tile-type": "file-tile",
+        }
+        for i, url in enumerate(tile_urls)
+    ]
+    return plistlib.dumps({"persistent-apps": apps}).decode("utf-8")
+
+
+class TestDockGuard(unittest.TestCase):
+    def test_decode_dock_file_url(self):
+        mod = _load("bundle")
+        self.assertEqual(
+            mod._decode_dock_file_url("file:///Applications/MarkView.app/"),
+            Path("/Applications/MarkView.app"),
+        )
+        self.assertEqual(
+            mod._decode_dock_file_url("file:///tmp/Google%20Chrome.app/"),
+            Path("/tmp/Google Chrome.app"),
+        )
+        self.assertIsNone(mod._decode_dock_file_url(""))
+        self.assertIsNone(mod._decode_dock_file_url("not-a-url"))
+
+    def test_read_dock_persistent_apps_parses_real_shaped_export(self):
+        mod = _load("bundle")
+        xml = _dock_export_xml(["file:///Applications/MarkView.app/"])
+        mod._run = lambda cmd, cwd=None: (0, xml, "")
+        apps = mod.read_dock_persistent_apps()
+        self.assertEqual(len(apps), 1)
+        self.assertEqual(
+            apps[0]["tile-data"]["file-data"]["_CFURLString"],
+            "file:///Applications/MarkView.app/",
+        )
+
+    def test_read_dock_persistent_apps_returns_empty_on_export_failure(self):
+        mod = _load("bundle")
+        mod._run = lambda cmd, cwd=None: (1, "", "no such domain")
+        self.assertEqual(mod.read_dock_persistent_apps(), [])
+
+    def test_read_dock_persistent_apps_returns_empty_on_garbage_output(self):
+        mod = _load("bundle")
+        mod._run = lambda cmd, cwd=None: (0, "not a plist", "")
+        self.assertEqual(mod.read_dock_persistent_apps(), [])
+
+    def test_find_dock_tiles_pointing_at_build_matches_nested_path(self):
+        mod = _load("bundle")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            xml = _dock_export_xml(
+                [
+                    f"file://{project_dir}/build/Build/Products/Release/MarkView.app/",
+                    "file:///Applications/MarkView.app/",
+                ]
+            )
+            mod._run = lambda cmd, cwd=None: (0, xml, "")
+            hits = mod.find_dock_tiles_pointing_at_build(project_dir)
+        self.assertEqual(len(hits), 1)
+        self.assertIn("build/Build/Products/Release/MarkView.app", hits[0])
+
+    def test_find_dock_tiles_pointing_at_build_no_hits(self):
+        mod = _load("bundle")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            xml = _dock_export_xml(["file:///Applications/MarkView.app/"])
+            mod._run = lambda cmd, cwd=None: (0, xml, "")
+            hits = mod.find_dock_tiles_pointing_at_build(project_dir)
+        self.assertEqual(hits, [])
+
+    def test_check_dock_not_pointing_at_build_raises_without_force(self):
+        mod = _load("bundle")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            xml = _dock_export_xml([f"file://{project_dir}/build/MarkView.app/"])
+            mod._run = lambda cmd, cwd=None: (0, xml, "")
+            with self.assertRaises(mod.BundleError) as cm:
+                mod.check_dock_not_pointing_at_build(project_dir, force=False)
+        msg = str(cm.exception)
+        self.assertIn("Dock has a tile pinned to a build/ output path", msg)
+        self.assertIn(str(project_dir), msg)
+        self.assertIn("--force", msg)
+
+    def test_check_dock_not_pointing_at_build_force_warns_not_raises(self):
+        mod = _load("bundle")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            xml = _dock_export_xml([f"file://{project_dir}/build/MarkView.app/"])
+            mod._run = lambda cmd, cwd=None: (0, xml, "")
+            out = []
+            mod.check_dock_not_pointing_at_build(
+                project_dir, force=True, out=out.append
+            )
+        self.assertTrue(any("build/" in line for line in out))
+
+    def test_check_dock_not_pointing_at_build_no_dock_hits_is_silent(self):
+        mod = _load("bundle")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            mod._run = lambda cmd, cwd=None: (0, "", "")
+            out = []
+            mod.check_dock_not_pointing_at_build(
+                project_dir, force=False, out=out.append
+            )
+        self.assertEqual(out, [])
+
+    def test_run_bundle_install_aborts_before_build_when_dock_pinned(self):
+        mod = _load("bundle")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            xml = _dock_export_xml([f"file://{project_dir}/build/MarkView.app/"])
+            calls = []
+
+            def fake_run(cmd, cwd=None):
+                calls.append(cmd)
+                if cmd[0] == "defaults":
+                    return 0, xml, ""
+                return 0, "", ""
+
+            mod._run = fake_run
+            with self.assertRaises(mod.BundleError) as cm:
+                mod.run_bundle(["--install"], project_dir=project_dir)
+        self.assertIn("build/ output path", str(cm.exception))
+        # No xcodegen/xcodebuild/security calls happened — the guard fired first.
+        self.assertFalse(any(c[0] == "xcodebuild" for c in calls))
 
 
 # ── bump_build_number ─────────────────────────────────────────────────────────

--- a/scripts/test-bundle.py
+++ b/scripts/test-bundle.py
@@ -70,15 +70,11 @@ class TestHelpers(unittest.TestCase):
         mod = _load("bundle")
         self.assertEqual(mod.parse_args(["--install"]), (True, False, False))
         self.assertEqual(mod.parse_args(["--notarize"]), (False, True, False))
-        self.assertEqual(
-            mod.parse_args(["--install", "--notarize"]), (True, True, False)
-        )
+        self.assertEqual(mod.parse_args(["--install", "--notarize"]), (True, True, False))
 
     def test_parse_args_force(self):
         mod = _load("bundle")
-        self.assertEqual(
-            mod.parse_args(["--install", "--force"]), (True, False, True)
-        )
+        self.assertEqual(mod.parse_args(["--install", "--force"]), (True, False, True))
 
     def test_parse_args_unknown_option_raises(self):
         mod = _load("bundle")
@@ -221,7 +217,7 @@ class TestDockGuard(unittest.TestCase):
         mod._run = lambda cmd, cwd=None: (0, "not a plist", "")
         self.assertEqual(mod.read_dock_persistent_apps(), [])
 
-    def test_find_dock_tiles_pointing_at_build_matches_nested_path(self):
+    def test_find_dock_tiles_pointing_at_ephemeral_output_matches_nested_path(self):
         mod = _load("bundle")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td)
@@ -232,51 +228,65 @@ class TestDockGuard(unittest.TestCase):
                 ]
             )
             mod._run = lambda cmd, cwd=None: (0, xml, "")
-            hits = mod.find_dock_tiles_pointing_at_build(project_dir)
+            hits = mod.find_dock_tiles_pointing_at_ephemeral_output(project_dir)
         self.assertEqual(len(hits), 1)
         self.assertIn("build/Build/Products/Release/MarkView.app", hits[0])
 
-    def test_find_dock_tiles_pointing_at_build_no_hits(self):
+    def test_find_dock_tiles_pointing_at_ephemeral_output_matches_repo_root_app(self):
+        mod = _load("bundle")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            xml = _dock_export_xml(
+                [
+                    f"file://{project_dir}/MarkView.app/",
+                    "file:///Applications/MarkView.app/",
+                ]
+            )
+            mod._run = lambda cmd, cwd=None: (0, xml, "")
+            hits = mod.find_dock_tiles_pointing_at_ephemeral_output(project_dir)
+        self.assertEqual(len(hits), 1)
+        self.assertIn(f"{project_dir}/MarkView.app", hits[0])
+        self.assertNotIn("/Applications", hits[0])
+
+    def test_find_dock_tiles_pointing_at_ephemeral_output_no_hits(self):
         mod = _load("bundle")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td)
             xml = _dock_export_xml(["file:///Applications/MarkView.app/"])
             mod._run = lambda cmd, cwd=None: (0, xml, "")
-            hits = mod.find_dock_tiles_pointing_at_build(project_dir)
+            hits = mod.find_dock_tiles_pointing_at_ephemeral_output(project_dir)
         self.assertEqual(hits, [])
 
-    def test_check_dock_not_pointing_at_build_raises_without_force(self):
+    def test_check_dock_not_pointing_at_ephemeral_output_raises_without_force(self):
         mod = _load("bundle")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td)
             xml = _dock_export_xml([f"file://{project_dir}/build/MarkView.app/"])
             mod._run = lambda cmd, cwd=None: (0, xml, "")
             with self.assertRaises(mod.BundleError) as cm:
-                mod.check_dock_not_pointing_at_build(project_dir, force=False)
+                mod.check_dock_not_pointing_at_ephemeral_output(project_dir, force=False)
         msg = str(cm.exception)
-        self.assertIn("Dock has a tile pinned to a build/ output path", msg)
+        self.assertIn("Dock has a tile pinned to an ephemeral output path", msg)
         self.assertIn(str(project_dir), msg)
         self.assertIn("--force", msg)
 
-    def test_check_dock_not_pointing_at_build_force_warns_not_raises(self):
+    def test_check_dock_not_pointing_at_ephemeral_output_force_warns_not_raises(self):
         mod = _load("bundle")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td)
             xml = _dock_export_xml([f"file://{project_dir}/build/MarkView.app/"])
             mod._run = lambda cmd, cwd=None: (0, xml, "")
             out = []
-            mod.check_dock_not_pointing_at_build(
-                project_dir, force=True, out=out.append
-            )
+            mod.check_dock_not_pointing_at_ephemeral_output(project_dir, force=True, out=out.append)
         self.assertTrue(any("build/" in line for line in out))
 
-    def test_check_dock_not_pointing_at_build_no_dock_hits_is_silent(self):
+    def test_check_dock_not_pointing_at_ephemeral_output_no_dock_hits_is_silent(self):
         mod = _load("bundle")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td)
             mod._run = lambda cmd, cwd=None: (0, "", "")
             out = []
-            mod.check_dock_not_pointing_at_build(
+            mod.check_dock_not_pointing_at_ephemeral_output(
                 project_dir, force=False, out=out.append
             )
         self.assertEqual(out, [])
@@ -297,7 +307,7 @@ class TestDockGuard(unittest.TestCase):
             mod._run = fake_run
             with self.assertRaises(mod.BundleError) as cm:
                 mod.run_bundle(["--install"], project_dir=project_dir)
-        self.assertIn("build/ output path", str(cm.exception))
+        self.assertIn("ephemeral output path", str(cm.exception))
         # No xcodegen/xcodebuild/security calls happened — the guard fired first.
         self.assertFalse(any(c[0] == "xcodebuild" for c in calls))
 
@@ -320,9 +330,7 @@ class TestBumpBuildNumber(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
             _write_plist(tmp / "Sources/MarkView/Info.plist", {"CFBundleVersion": "1"})
-            _write_plist(
-                tmp / "Sources/MarkViewQuickLook/Info.plist", {"CFBundleVersion": "1"}
-            )
+            _write_plist(tmp / "Sources/MarkViewQuickLook/Info.plist", {"CFBundleVersion": "1"})
             build = mod.bump_build_number(tmp)
         self.assertEqual(build, "42")
         plutil_calls = [c for c in calls if c[0] == "plutil"]
@@ -379,9 +387,7 @@ class TestBumpBuildNumber(unittest.TestCase):
 
 
 class TestVerifyBundleStructure(unittest.TestCase):
-    def _make_app(
-        self, tmp: Path, *, with_doctypes: bool = True, with_ql: bool = True
-    ) -> Path:
+    def _make_app(self, tmp: Path, *, with_doctypes: bool = True, with_ql: bool = True) -> Path:
         app_dir = tmp / "MarkView.app"
         _write_exec(app_dir / "Contents/MacOS/MarkView")
         plist_data = {"CFBundleShortVersionString": "9.9.9"}
@@ -405,9 +411,7 @@ class TestVerifyBundleStructure(unittest.TestCase):
             tmp = Path(td)
             app_dir = self._make_app(tmp)
             out = []
-            valid = mod.verify_bundle_structure(
-                app_dir, "Developer ID Application", out.append
-            )
+            valid = mod.verify_bundle_structure(app_dir, "Developer ID Application", out.append)
         self.assertTrue(valid)
         self.assertIn("=== Bundle verification passed ===", out)
         self.assertIn("  ✓ Quick Look extension exists", out)
@@ -448,9 +452,7 @@ class TestVerifyBundleStructure(unittest.TestCase):
             tmp = Path(td)
             app_dir = self._make_app(tmp)
             out = []
-            valid = mod.verify_bundle_structure(
-                app_dir, "Developer ID Application", out.append
-            )
+            valid = mod.verify_bundle_structure(app_dir, "Developer ID Application", out.append)
         self.assertFalse(valid)
         self.assertIn(
             "  ✗ Code signature invalid with Developer ID — bundle will be rejected by Gatekeeper",
@@ -472,9 +474,7 @@ class TestVerifyBundleStructure(unittest.TestCase):
             out = []
             valid = mod.verify_bundle_structure(app_dir, "-", out.append)
         self.assertTrue(valid)
-        self.assertIn(
-            "  ⚠ Ad-hoc signature (expected — no Developer ID cert found)", out
-        )
+        self.assertIn("  ⚠ Ad-hoc signature (expected — no Developer ID cert found)", out)
 
 
 # ── install_bundle ────────────────────────────────────────────────────────────
@@ -600,16 +600,13 @@ def _build_fake_release_app(build_products: Path) -> None:
     )
     (build_products / "Contents/PkgInfo").write_text("APPL????")
     _write_exec(
-        build_products
-        / "Contents/PlugIns/MarkViewQuickLook.appex/Contents/MacOS/MarkViewQuickLook"
+        build_products / "Contents/PlugIns/MarkViewQuickLook.appex/Contents/MacOS/MarkViewQuickLook"
     )
     _write_plist(
         build_products / "Contents/PlugIns/MarkViewQuickLook.appex/Contents/Info.plist",
         {"CFBundleShortVersionString": "9.9.9"},
     )
-    sentry_bin = (
-        build_products / "Contents/Frameworks/Sentry.framework/Versions/A/Sentry"
-    )
+    sentry_bin = build_products / "Contents/Frameworks/Sentry.framework/Versions/A/Sentry"
     _write_exec(sentry_bin)
     (build_products / "Contents/Resources/MarkView_MarkViewCore.bundle").mkdir(
         parents=True, exist_ok=True
@@ -619,16 +616,10 @@ def _build_fake_release_app(build_products: Path) -> None:
 class TestGoldenCharacterization(unittest.TestCase):
     def _make_project(self, tmp: Path) -> None:
         _write_plist(tmp / "Sources/MarkView/Info.plist", {"CFBundleVersion": "1"})
-        _write_plist(
-            tmp / "Sources/MarkViewQuickLook/Info.plist", {"CFBundleVersion": "1"}
-        )
-        (tmp / "Sources/MarkView/MarkView.entitlements").parent.mkdir(
-            parents=True, exist_ok=True
-        )
+        _write_plist(tmp / "Sources/MarkViewQuickLook/Info.plist", {"CFBundleVersion": "1"})
+        (tmp / "Sources/MarkView/MarkView.entitlements").parent.mkdir(parents=True, exist_ok=True)
         (tmp / "Sources/MarkView/MarkView.entitlements").write_text("<plist/>")
-        (tmp / "Sources/MarkViewQuickLook/MarkViewQuickLook.entitlements").write_text(
-            "<plist/>"
-        )
+        (tmp / "Sources/MarkViewQuickLook/MarkViewQuickLook.entitlements").write_text("<plist/>")
 
     def _fake_run(self, tmp: Path, install_dir: Path):
         build_products = tmp / "build/Build/Products/Release/MarkView.app"
@@ -699,12 +690,8 @@ class TestGoldenCharacterization(unittest.TestCase):
                 "Contents/MacOS/markview-mcp-server",
                 "Contents/PlugIns/MarkViewQuickLook.appex/Contents/MacOS/MarkViewQuickLook",
             ):
-                self.assertTrue(
-                    (app_dir / rel).exists(), f"missing in app bundle: {rel}"
-                )
-                self.assertTrue(
-                    (install_dir / rel).exists(), f"missing in installed copy: {rel}"
-                )
+                self.assertTrue((app_dir / rel).exists(), f"missing in app bundle: {rel}")
+                self.assertTrue((install_dir / rel).exists(), f"missing in installed copy: {rel}")
 
     def test_run_bundle_without_install_skips_install_dir(self):
         mod = _load("bundle")
@@ -716,9 +703,7 @@ class TestGoldenCharacterization(unittest.TestCase):
             mod._which = lambda name: "/opt/homebrew/bin/xcodegen"
 
             out = []
-            rc = mod.run_bundle(
-                [], project_dir=tmp, install_dir=install_dir, out=out.append
-            )
+            rc = mod.run_bundle([], project_dir=tmp, install_dir=install_dir, out=out.append)
 
         self.assertEqual(rc, 0)
         self.assertFalse(install_dir.exists())
@@ -842,9 +827,7 @@ class TestFailurePaths(unittest.TestCase):
 class TestMain(unittest.TestCase):
     def test_main_exits_with_bundle_error_code(self):
         mod = _load("bundle")
-        mod.run_bundle = lambda argv, **kw: (_ for _ in ()).throw(
-            mod.BundleError("boom", code=3)
-        )
+        mod.run_bundle = lambda argv, **kw: (_ for _ in ()).throw(mod.BundleError("boom", code=3))
         with (
             patch.object(sys, "argv", ["bundle.py"]),
             patch("sys.stderr", new_callable=StringIO) as err,

--- a/scripts/test-dev-cleanup.py
+++ b/scripts/test-dev-cleanup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Tests for dev-cleanup.py (mar-048).
+Tests for dev_cleanup.py (mar-048).
 
 Tier 2 behavioral tests against real temp directories (no subprocess calls
-in dev-cleanup.py at all, so nothing to stub) — every test builds an
+in dev_cleanup.py at all, so nothing to stub) — every test builds an
 isolated `project_dir` / `home` under tempfile.TemporaryDirectory() and
 asserts against that, never the real repo or the real
 ~/Library/Developer/Xcode/DerivedData.
@@ -40,15 +40,15 @@ def _write_file(path: Path, size: int) -> None:
 
 class TestParseArgs(unittest.TestCase):
     def test_defaults_to_dry_run(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         self.assertEqual(mod.parse_args([]), False)
 
     def test_apply_flag(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         self.assertEqual(mod.parse_args(["--apply"]), True)
 
     def test_unknown_option_raises(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with self.assertRaises(mod.CleanupError) as cm:
             mod.parse_args(["--bogus"])
         self.assertIn("Unknown option: --bogus", str(cm.exception))
@@ -60,15 +60,19 @@ class TestParseArgs(unittest.TestCase):
 
 class TestHumanSize(unittest.TestCase):
     def test_bytes(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         self.assertEqual(mod.human_size(0), "0 B")
         self.assertEqual(mod.human_size(512), "512 B")
 
     def test_kb_mb_gb(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         self.assertEqual(mod.human_size(2048), "2.0 KB")
         self.assertEqual(mod.human_size(5 * 1024 * 1024), "5.0 MB")
         self.assertEqual(mod.human_size(3 * 1024 * 1024 * 1024), "3.0 GB")
+
+    def test_tb(self):
+        mod = _load("dev_cleanup")
+        self.assertEqual(mod.human_size(2 * 1024 * 1024 * 1024 * 1024), "2.0 TB")
 
 
 # ── _dir_size ────────────────────────────────────────────────────────────────
@@ -76,7 +80,7 @@ class TestHumanSize(unittest.TestCase):
 
 class TestDirSize(unittest.TestCase):
     def test_sums_nested_files(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
             _write_file(tmp / "a.txt", 100)
@@ -84,15 +88,41 @@ class TestDirSize(unittest.TestCase):
             self.assertEqual(mod._dir_size(tmp), 300)
 
     def test_single_file(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             f = Path(td) / "solo.bin"
             _write_file(f, 42)
             self.assertEqual(mod._dir_size(f), 42)
 
     def test_missing_path_is_zero(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         self.assertEqual(mod._dir_size(Path("/nonexistent/path/xyz")), 0)
+
+
+# ── static_targets ───────────────────────────────────────────────────────────
+
+
+class TestStaticTargets(unittest.TestCase):
+    def test_returns_build_and_app_roots_unconditionally(self):
+        mod = _load("dev_cleanup")
+        project_dir = Path("/tmp/does-not-exist-repo")
+        self.assertEqual(
+            mod.static_targets(project_dir),
+            [project_dir / "build", project_dir / "MarkView.app"],
+        )
+
+    def test_find_targets_static_prefix_matches_static_targets(self):
+        """Drift guard: find_targets' project-relative prefix must always
+        equal static_targets() — this is the list scripts/bundle.py's
+        Dock-tile guard matches against, so the two must never diverge."""
+        mod = _load("dev_cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "repo"
+            home = Path(td) / "home"
+            (project_dir / "build").mkdir(parents=True)
+            (project_dir / "MarkView.app").mkdir(parents=True)
+            targets = mod.find_targets(project_dir, home)
+        self.assertEqual(targets[:2], mod.static_targets(project_dir))
 
 
 # ── find_targets ─────────────────────────────────────────────────────────────
@@ -100,7 +130,7 @@ class TestDirSize(unittest.TestCase):
 
 class TestFindTargets(unittest.TestCase):
     def test_returns_only_existing_targets(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td) / "repo"
             home = Path(td) / "home"
@@ -110,7 +140,7 @@ class TestFindTargets(unittest.TestCase):
         self.assertEqual(targets, [project_dir / "build"])
 
     def test_finds_app_bundle_and_derived_data(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td) / "repo"
             home = Path(td) / "home"
@@ -130,7 +160,7 @@ class TestFindTargets(unittest.TestCase):
         self.assertNotIn(dd / "OtherProject-xyz789", targets)
 
     def test_no_targets_when_nothing_exists(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td) / "repo"
             home = Path(td) / "home"
@@ -143,7 +173,7 @@ class TestFindTargets(unittest.TestCase):
 
 class TestRunCleanupDryRun(unittest.TestCase):
     def test_dry_run_lists_targets_and_deletes_nothing(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td) / "repo"
             home = Path(td) / "home"
@@ -164,7 +194,7 @@ class TestRunCleanupDryRun(unittest.TestCase):
             self.assertTrue((project_dir / "MarkView.app").exists())
 
     def test_no_targets_reports_nothing_to_clean(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td) / "repo"
             home = Path(td) / "home"
@@ -179,7 +209,7 @@ class TestRunCleanupDryRun(unittest.TestCase):
 
 class TestRunCleanupApply(unittest.TestCase):
     def test_apply_deletes_targets_and_reports_freed_size(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td) / "repo"
             home = Path(td) / "home"
@@ -199,7 +229,7 @@ class TestRunCleanupApply(unittest.TestCase):
         self.assertFalse(dd.exists())
 
     def test_apply_never_touches_unrelated_derived_data(self):
-        mod = _load("dev-cleanup")
+        mod = _load("dev_cleanup")
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td) / "repo"
             home = Path(td) / "home"

--- a/scripts/test-dev-cleanup.py
+++ b/scripts/test-dev-cleanup.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Tests for dev-cleanup.py (mar-048).
+
+Tier 2 behavioral tests against real temp directories (no subprocess calls
+in dev-cleanup.py at all, so nothing to stub) — every test builds an
+isolated `project_dir` / `home` under tempfile.TemporaryDirectory() and
+asserts against that, never the real repo or the real
+~/Library/Developer/Xcode/DerivedData.
+
+Usage:
+    python3 scripts/test-dev-cleanup.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).parent
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_file(path: Path, size: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+
+
+# ── parse_args ───────────────────────────────────────────────────────────────
+
+
+class TestParseArgs(unittest.TestCase):
+    def test_defaults_to_dry_run(self):
+        mod = _load("dev-cleanup")
+        self.assertEqual(mod.parse_args([]), False)
+
+    def test_apply_flag(self):
+        mod = _load("dev-cleanup")
+        self.assertEqual(mod.parse_args(["--apply"]), True)
+
+    def test_unknown_option_raises(self):
+        mod = _load("dev-cleanup")
+        with self.assertRaises(mod.CleanupError) as cm:
+            mod.parse_args(["--bogus"])
+        self.assertIn("Unknown option: --bogus", str(cm.exception))
+        self.assertIn("--apply", str(cm.exception))
+
+
+# ── human_size ───────────────────────────────────────────────────────────────
+
+
+class TestHumanSize(unittest.TestCase):
+    def test_bytes(self):
+        mod = _load("dev-cleanup")
+        self.assertEqual(mod.human_size(0), "0 B")
+        self.assertEqual(mod.human_size(512), "512 B")
+
+    def test_kb_mb_gb(self):
+        mod = _load("dev-cleanup")
+        self.assertEqual(mod.human_size(2048), "2.0 KB")
+        self.assertEqual(mod.human_size(5 * 1024 * 1024), "5.0 MB")
+        self.assertEqual(mod.human_size(3 * 1024 * 1024 * 1024), "3.0 GB")
+
+
+# ── _dir_size ────────────────────────────────────────────────────────────────
+
+
+class TestDirSize(unittest.TestCase):
+    def test_sums_nested_files(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            _write_file(tmp / "a.txt", 100)
+            _write_file(tmp / "nested/b.txt", 200)
+            self.assertEqual(mod._dir_size(tmp), 300)
+
+    def test_single_file(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "solo.bin"
+            _write_file(f, 42)
+            self.assertEqual(mod._dir_size(f), 42)
+
+    def test_missing_path_is_zero(self):
+        mod = _load("dev-cleanup")
+        self.assertEqual(mod._dir_size(Path("/nonexistent/path/xyz")), 0)
+
+
+# ── find_targets ─────────────────────────────────────────────────────────────
+
+
+class TestFindTargets(unittest.TestCase):
+    def test_returns_only_existing_targets(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "repo"
+            home = Path(td) / "home"
+            (project_dir / "build").mkdir(parents=True)
+            # MarkView.app and DerivedData deliberately absent.
+            targets = mod.find_targets(project_dir, home)
+        self.assertEqual(targets, [project_dir / "build"])
+
+    def test_finds_app_bundle_and_derived_data(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "repo"
+            home = Path(td) / "home"
+            (project_dir / "build").mkdir(parents=True)
+            (project_dir / "MarkView.app").mkdir(parents=True)
+            dd = home / "Library/Developer/Xcode/DerivedData"
+            (dd / "MarkView-abc123").mkdir(parents=True)
+            (dd / "MarkView-def456").mkdir(parents=True)
+            (dd / "OtherProject-xyz789").mkdir(parents=True)  # must NOT match
+
+            targets = mod.find_targets(project_dir, home)
+
+        self.assertIn(project_dir / "build", targets)
+        self.assertIn(project_dir / "MarkView.app", targets)
+        self.assertIn(dd / "MarkView-abc123", targets)
+        self.assertIn(dd / "MarkView-def456", targets)
+        self.assertNotIn(dd / "OtherProject-xyz789", targets)
+
+    def test_no_targets_when_nothing_exists(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "repo"
+            home = Path(td) / "home"
+            targets = mod.find_targets(project_dir, home)
+        self.assertEqual(targets, [])
+
+
+# ── run_cleanup: dry run (default) ──────────────────────────────────────────
+
+
+class TestRunCleanupDryRun(unittest.TestCase):
+    def test_dry_run_lists_targets_and_deletes_nothing(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "repo"
+            home = Path(td) / "home"
+            _write_file(project_dir / "build/obj.o", 1024)
+            _write_file(project_dir / "MarkView.app/Contents/MacOS/MarkView", 2048)
+
+            out = []
+            rc = mod.run_cleanup([], project_dir=project_dir, home=home, out=out.append)
+
+            self.assertEqual(rc, 0)
+            text = "\n".join(out)
+            self.assertIn("dry run", text.lower())
+            self.assertIn(str(project_dir / "build"), text)
+            self.assertIn(str(project_dir / "MarkView.app"), text)
+            self.assertIn("Dry run only", text)
+            # Nothing deleted.
+            self.assertTrue((project_dir / "build/obj.o").exists())
+            self.assertTrue((project_dir / "MarkView.app").exists())
+
+    def test_no_targets_reports_nothing_to_clean(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "repo"
+            home = Path(td) / "home"
+            out = []
+            rc = mod.run_cleanup([], project_dir=project_dir, home=home, out=out.append)
+        self.assertEqual(rc, 0)
+        self.assertIn("Nothing to clean", "\n".join(out))
+
+
+# ── run_cleanup: --apply ─────────────────────────────────────────────────────
+
+
+class TestRunCleanupApply(unittest.TestCase):
+    def test_apply_deletes_targets_and_reports_freed_size(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "repo"
+            home = Path(td) / "home"
+            _write_file(project_dir / "build/obj.o", 1024)
+            _write_file(project_dir / "MarkView.app/Contents/MacOS/MarkView", 1024)
+            dd = home / "Library/Developer/Xcode/DerivedData/MarkView-abc123"
+            _write_file(dd / "Logs/build.log", 1024)
+
+            out = []
+            rc = mod.run_cleanup(["--apply"], project_dir=project_dir, home=home, out=out.append)
+
+        self.assertEqual(rc, 0)
+        text = "\n".join(out)
+        self.assertIn("Freed", text)
+        self.assertFalse((project_dir / "build").exists())
+        self.assertFalse((project_dir / "MarkView.app").exists())
+        self.assertFalse(dd.exists())
+
+    def test_apply_never_touches_unrelated_derived_data(self):
+        mod = _load("dev-cleanup")
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "repo"
+            home = Path(td) / "home"
+            other_dd = home / "Library/Developer/Xcode/DerivedData/OtherProject-xyz789"
+            _write_file(other_dd / "Logs/build.log", 1024)
+            _write_file(project_dir / "build/obj.o", 1024)
+
+            out = []
+            mod.run_cleanup(["--apply"], project_dir=project_dir, home=home, out=out.append)
+
+            self.assertTrue(other_dd.exists())
+
+
+# ── Verify wiring ────────────────────────────────────────────────────────────
+
+
+class TestVerifyWiring(unittest.TestCase):
+    def test_verify_py_runs_this_suite(self):
+        verify_source = (SCRIPTS / "verify.py").read_text()
+        self.assertIn("test-dev-cleanup.py", verify_source)
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(__import__("__main__"))
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -23,21 +23,13 @@ from pathlib import Path
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent
 APP_BUNDLE = PROJECT_DIR / "MarkView.app"
-BUNDLE_RSRC = (
-    APP_BUNDLE / "Contents/Resources/MarkView_MarkViewCore.bundle/Contents/Resources"
-)
+BUNDLE_RSRC = APP_BUNDLE / "Contents/Resources/MarkView_MarkViewCore.bundle/Contents/Resources"
 APPEX = APP_BUNDLE / "Contents/PlugIns/MarkViewQuickLook.appex"
-APPEX_RSRC = (
-    APPEX / "Contents/Resources/MarkView_MarkViewCore.bundle/Contents/Resources"
-)
+APPEX_RSRC = APPEX / "Contents/Resources/MarkView_MarkViewCore.bundle/Contents/Resources"
 INSTALLED_APP = Path("/Applications/MarkView.app")
 
-_GLOBAL_STAMP_DEFAULT = (
-    Path.home() / "repos/claude-repl-template/.claude/memory/.last-verify-at"
-)
-GLOBAL_STAMP = Path(
-    os.environ.get("COMMIT_GATE_VERIFY_STAMP", str(_GLOBAL_STAMP_DEFAULT))
-)
+_GLOBAL_STAMP_DEFAULT = Path.home() / "repos/claude-repl-template/.claude/memory/.last-verify-at"
+GLOBAL_STAMP = Path(os.environ.get("COMMIT_GATE_VERIFY_STAMP", str(_GLOBAL_STAMP_DEFAULT)))
 PER_REPO_STAMP = PROJECT_DIR / ".last-verify-at"
 
 RESOURCES = ["mermaid.min.js", "prism-bundle.min.js", "template.html"]
@@ -211,9 +203,7 @@ def tier_bundle() -> bool:
 
     # Code signing
     print("\n  --- Signing Verification ---")
-    rc, _ = run_captured(
-        ["codesign", "--verify", "--deep", "--strict", str(APP_BUNDLE)]
-    )
+    rc, _ = run_captured(["codesign", "--verify", "--deep", "--strict", str(APP_BUNDLE)])
     if rc == 0:
         print("  ✓ Code signature valid (deep + strict)")
     else:
@@ -229,9 +219,7 @@ def tier_bundle() -> bool:
         print("  Signing: unknown")
 
     if "Developer ID" in authority:
-        rc, _ = run_captured(
-            ["spctl", "--assess", "--type", "execute", str(APP_BUNDLE)]
-        )
+        rc, _ = run_captured(["spctl", "--assess", "--type", "execute", str(APP_BUNDLE)])
         print(
             "  ✓ Gatekeeper: accepted"
             if rc == 0
@@ -283,12 +271,8 @@ def tier_golden_drift() -> bool:
     _, out = run_filtered(["swift", "run", "MarkViewTestRunner", "--generate-goldens"])
     if out.strip():
         print(out)
-    rc, diff_stat = run_captured(
-        ["git", "diff", "--stat", "Tests/TestRunner/Fixtures/expected/"]
-    )
-    rc2, _ = run_captured(
-        ["git", "diff", "--quiet", "Tests/TestRunner/Fixtures/expected/"]
-    )
+    rc, diff_stat = run_captured(["git", "diff", "--stat", "Tests/TestRunner/Fixtures/expected/"])
+    rc2, _ = run_captured(["git", "diff", "--quiet", "Tests/TestRunner/Fixtures/expected/"])
     if rc2 == 0:
         ok("Golden baselines are up to date")
         return True
@@ -315,7 +299,7 @@ def tier_script_tests() -> bool:
         ("scripts/test-ci-status.py", "ci_status"),
         ("scripts/test-sentry-check.py", "sentry_check"),
         ("scripts/test-bundle.py", "bundle"),
-        ("scripts/test-dev-cleanup.py", "dev-cleanup"),
+        ("scripts/test-dev-cleanup.py", "dev_cleanup"),
     ]
     all_passed = True
     for rel_path, label in suites:
@@ -381,13 +365,9 @@ def tier_extended_visual() -> bool:
 
 def tier_extended_ql() -> bool:
     header("Extended: Quick Look System Integration")
-    ql_appex = Path(
-        "/Applications/MarkView.app/Contents/PlugIns/MarkViewQuickLook.appex"
-    )
+    ql_appex = Path("/Applications/MarkView.app/Contents/PlugIns/MarkViewQuickLook.appex")
     if not ql_appex.is_dir():
-        skip(
-            "Quick Look extension not installed (run: bash scripts/bundle.sh --install)"
-        )
+        skip("Quick Look extension not installed (run: bash scripts/bundle.sh --install)")
         return True
 
     passed = 0
@@ -428,9 +408,7 @@ def tier_extended_ql() -> bool:
         )
 
     rc, _ = run_captured(["plutil", "-lint", str(ql_appex / "Contents/Info.plist")])
-    ql_check(
-        rc == 0, "Extension Info.plist is valid XML", "Extension Info.plist is invalid"
-    )
+    ql_check(rc == 0, "Extension Info.plist is valid XML", "Extension Info.plist is invalid")
 
     _, plist_content = run_captured(
         ["plutil", "-convert", "xml1", "-o", "-", str(ql_appex / "Contents/Info.plist")]
@@ -441,9 +419,7 @@ def tier_extended_ql() -> bool:
         "QLSupportedContentTypes",
         "CFBundleIdentifier",
     ]:
-        ql_check(
-            key in plist_content, f"Info.plist has {key}", f"Info.plist missing {key}"
-        )
+        ql_check(key in plist_content, f"Info.plist has {key}", f"Info.plist missing {key}")
 
     _, ext_point = run_captured(
         [
@@ -482,9 +458,7 @@ def tier_extended_ql() -> bool:
         print("  ✓ Developer ID signed — Finder spacebar preview should work")
         passed += 1
 
-    _, arch_out = run_captured(
-        ["file", str(ql_appex / "Contents/MacOS/MarkViewQuickLook")]
-    )
+    _, arch_out = run_captured(["file", str(ql_appex / "Contents/MacOS/MarkViewQuickLook")])
     ql_check(
         "arm64" in arch_out or "Mach-O" in arch_out,
         "Binary is valid Mach-O/arm64",
@@ -549,15 +523,11 @@ def tier_extended_ql() -> bool:
             )
             failed += 1
         else:
-            ql_warn(
-                "Extension NOT registered with pluginkit (expected for ad-hoc signed apps)"
-            )
+            ql_warn("Extension NOT registered with pluginkit (expected for ad-hoc signed apps)")
 
     fixture = PROJECT_DIR / "Tests/TestRunner/Fixtures/basic.md"
     if fixture.is_file():
-        _, md_type_out = run_captured(
-            ["mdls", "-attr", "kMDItemContentType", str(fixture)]
-        )
+        _, md_type_out = run_captured(["mdls", "-attr", "kMDItemContentType", str(fixture)])
         import re
 
         m = re.search(r'"([^"]+)"', md_type_out)
@@ -570,9 +540,7 @@ def tier_extended_ql() -> bool:
         else:
             ql_warn("Could not determine UTType for .md files")
 
-    print(
-        f"\n  Quick Look E2E: {passed} passed, {failed} failed, {skipped} skipped/advisory"
-    )
+    print(f"\n  Quick Look E2E: {passed} passed, {failed} failed, {skipped} skipped/advisory")
     if failed > 0:
         fail("Quick Look integration has failures")
         return False

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -315,6 +315,7 @@ def tier_script_tests() -> bool:
         ("scripts/test-ci-status.py", "ci_status"),
         ("scripts/test-sentry-check.py", "sentry_check"),
         ("scripts/test-bundle.py", "bundle"),
+        ("scripts/test-dev-cleanup.py", "dev-cleanup"),
     ]
     all_passed = True
     for rel_path, label in suites:


### PR DESCRIPTION
## Summary

**mar-047 (P3) - Verify is now a required status check on main.**
PR #70 (`mar-045: migrate bundle.sh to tested Python`) auto-merged with a
**red** `Verify` check because that check-run wasn't in the branch's
required-status-checks list. Fixed live via the GitHub API (this is the one
task allowed to touch repo settings):

- Before: `required_status_checks.contexts = ["Build & Test", "Golden Drift Check"]`
- After: `required_status_checks.contexts = ["Build & Test", "Golden Drift Check", "Verify"]`
- `strict` stayed `false` (unchanged).
- Full before/after protection JSON saved locally to
  `docs/personal/branch-protection-before-2026-09-07.json` and
  `docs/personal/branch-protection-after-2026-09-07.json` (gitignored -
  not part of this diff).

**Workflow path-filter check:** `.github/workflows/ci.yml`'s `verify` job
has no `paths:`/`paths-ignore:` filter at the job or workflow level - it
runs on every `push`/`pull_request` to `main` unconditionally (only
`needs: build`), so it can already always report on every PR. No workflow
change was needed for the "can't report" failure mode described in the
task.

**mar-048 (P2) - dev-build hardening pair.**
1. `scripts/bundle.py --install` now refuses (non-zero, clear message,
   `--force` override) if any pinned Dock tile points inside an ephemeral
   output path - the repo's `build/` output tree or the repo-root
   `MarkView.app` - both of which `scripts/dev_cleanup.py` (below) deletes,
   so a tile pinned to either silently breaks. The check reads the Dock via
   `defaults export com.apple.dock -` (never `defaults write` - the Dock is
   never mutated).
2. New `scripts/dev_cleanup.py`: dry-run by default, `--apply` to delete.
   Removes `build/`, the repo-root `MarkView.app`, and any
   `~/Library/Developer/Xcode/DerivedData/MarkView-*` products, printing
   each target's size before deletion. Nothing was deleted in this
   worktree or the main checkout - that reclaim run happens separately
   after merge.

Both follow the existing `scripts/bundle.py`/`scripts/test-bundle.py`
tested-Python conventions (stubbed subprocess boundary for bundle.py,
real tempdirs for dev_cleanup.py since it makes no subprocess calls) and
are wired into `scripts/verify.py`'s script-test tier.

## Review follow-up

Addressed every blocker/major and cheap-minor finding from the PR review:

- **Major - Dock guard missed its primary failure mode.** The guard only
  matched `build/`, not the repo-root `MarkView.app` that
  `dev_cleanup.py` also deletes (arguably the artifact a developer is
  most likely to have pinned). Fixed by extracting
  `dev_cleanup.static_targets(project_dir)` as the single source of truth
  for both ephemeral roots; `bundle.py` imports it, so the guard and the
  cleanup script's target list cannot drift apart again. Renamed
  `find_dock_tiles_pointing_at_build` -> `find_dock_tiles_pointing_at_ephemeral_output`
  to match its wider scope, and added
  `test_find_dock_tiles_pointing_at_ephemeral_output_matches_repo_root_app`
  plus a `find_targets`/`static_targets` drift-guard test.
- **Minor - `human_size()` TB bug.** The loop divided only 3 times
  (KB/MB/GB) then labeled the leftover value TB, understating anything
  >= 1 TiB by 1024x. Added the missing divide and a
  `TestHumanSize.test_tb` regression case.
- **Minor - `dev-cleanup.py` was the only hyphenated non-test module in
  `scripts/`.** Renamed to `scripts/dev_cleanup.py` (test file keeps
  `test-dev-cleanup.py` per the existing `test-*.py` convention); updated
  `scripts/verify.py`'s label and `CLAUDE.md`'s test list.
- **Minor - dead `out` parameter.** Dropped `out` from
  `read_dock_persistent_apps` and `find_dock_tiles_pointing_at_ephemeral_output`,
  neither of which ever called it.
  `check_dock_not_pointing_at_ephemeral_output` keeps `out` since it's
  the one that actually prints.
- **Minor - undocumented new surface.** Added
  `dev_cleanup.py [--apply]` and `bundle.sh --install --force` to
  `docs/ARCHITECTURE.md`'s and `README.md`'s dev-script blocks, and added
  an `## Unreleased` CHANGELOG section for mar-047/mar-048 (v1.7.2 is
  already tagged).

Re-ran the full canonical verifier after these fixes; still green (see
updated test plan below).

## Test plan
- [x] `python3 scripts/test-bundle.py` - 44 tests pass, including
      `TestDockGuard` coverage (URL decode, export-failure/garbage
      fallback, path matching against both ephemeral roots, `--force`
      override, and that `run_bundle(["--install"])` aborts *before* any
      xcodegen/xcodebuild call when a tile is pinned to `build/` or to
      the repo-root `MarkView.app`).
- [x] `python3 scripts/test-dev-cleanup.py` - 19 tests pass (dry-run
      lists + deletes nothing, `--apply` deletes + reports freed size,
      never touches unrelated `DerivedData/OtherProject-*`, no-targets
      case, `static_targets`/`find_targets` drift guard, TB-scale
      `human_size`, verify.py wiring).
- [x] `ruff check` on every touched script - clean.
- [x] Full canonical verifier: `taskpolicy -c utility python3 scripts/verify.py`
      -> `=== All checks passed ===`, verify stamps written (368 Swift
      tests, 4 PDF tests, golden drift clean, all script-test suites
      including the two dev-hardening ones, CLI check).
- [x] `gh api repos/paulhkang94/markview/branches/main/protection` confirms
      `Verify` is now in `required_status_checks.contexts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
