### PR TITLE
ci: pin Python 3.14 in ci.yml's Python-running jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
           fetch-depth: 0   # full clone — check-version-sync.sh checks git tag existence for BINARY_VERSION sync.
           # fetch-tags:true is insufficient with shallow clones; fetch-depth:0 is the correct fix.
 
+      # Explicit interpreter pin — fleet standard per
+      # docs/research/python-version-upgrade-evaluation-2026-09-11.md (~/repos/docs).
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
       - name: Cache SPM dependencies
         uses: actions/cache@v4
         with:
@@ -97,6 +104,14 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
+
+      # Explicit interpreter pin — fleet standard per
+      # docs/research/python-version-upgrade-evaluation-2026-09-11.md (~/repos/docs).
+      # scripts/bundle.sh execs bundle.py.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
 
       - name: Cache SPM dependencies
         uses: actions/cache@v4
@@ -132,6 +147,14 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
+
+      # Explicit interpreter pin — fleet standard per
+      # docs/research/python-version-upgrade-evaluation-2026-09-11.md (~/repos/docs).
+      # scripts/test-mcp.sh runs inline python3 harness code.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
 
       - name: Cache SPM dependencies
         uses: actions/cache@v4

--- a/scripts/rule-gates.json
+++ b/scripts/rule-gates.json
@@ -121,6 +121,14 @@
       "ci_pattern": "check_version_sync\\.py --expect-tag",
       "gate_type": "script_run",
       "tier": 1
+    },
+    {
+      "id": "python-jobs-pin-interpreter-in-ci",
+      "description": "Every ci.yml job that runs Python (verify, bundle, mcp) must pin an explicit interpreter via actions/setup-python instead of floating on the runner image's default python3 — see docs/research/python-version-upgrade-evaluation-2026-09-11.md (fleet standard: 3.14) in ~/repos/docs.",
+      "ci_files": [".github/workflows/ci.yml"],
+      "ci_pattern": "actions/setup-python@v5[\\s\\S]*?python-version:\\s*[\"']3\\.14[\"']",
+      "gate_type": "job",
+      "tier": 1
     }
   ]
 }


### PR DESCRIPTION
## Summary
- ci.yml had no `actions/setup-python`/`python-version` pin anywhere, so the `verify`, `bundle`, and `mcp` jobs floated on whatever Python macos-15 shipped by default.
- Add `actions/setup-python@v5` pinned to `python-version: "3.14"` (fleet standard, see `docs/research/python-version-upgrade-evaluation-2026-09-11.md` in `~/repos/docs`) to exactly those three jobs; `build`, `golden-check`, `visual-smoke`, `docs-audit`, and `sentry-release` are untouched since none of them invoke Python.
- Extended the existing `rule-gates.json`/`check_rule_gates.py` contract-test seam with a new `python-jobs-pin-interpreter-in-ci` rule so a future edit that drops the pin fails CI instead of drifting silently. Confirmed red (pattern absent) before the `ci.yml` change, green after.

## Test plan
- [x] `python3 scripts/check_rule_gates.py` — red before the `ci.yml` edit (new rule failed), green after (16 rules, 15 checked, 15 passed)
- [x] `python3 scripts/test-check-rule-gates.py` — 17 tests pass unaffected (uses synthetic manifests)
- [x] `bash Tests/test-rule-gates.sh` — 7 cases pass unaffected
- [x] `taskpolicy -c utility python3 scripts/verify.py` — `=== All checks passed ===`, stamps written

🤖 Generated with [Claude Code](https://claude.com/claude-code)
